### PR TITLE
fixed constructor of AssemblyLinkedResource not initializing fields

### DIFF
--- a/src/DotNet/Resource.cs
+++ b/src/DotNet/Resource.cs
@@ -320,6 +320,7 @@ namespace dnlib.DotNet {
 			: base(name, flags) {
 			if (asmRef == null)
 				throw new ArgumentNullException("asmRef");
+			this.asmRef = asmRef;
 		}
 
 		/// <inheritdoc/>


### PR DESCRIPTION
Initialization of asmRef field is missed...
