### PR TITLE
Use MemoryStreamCreator on Unix-like OS

### DIFF
--- a/src/PE/PEImage.cs
+++ b/src/PE/PEImage.cs
@@ -54,6 +54,17 @@ namespace dnlib.PE {
 		// is available, which will be slower.
 		const bool USE_MEMORY_LAYOUT_WITH_MAPPED_FILES = false;
 
+		// Current Memory-mapped files implementation uses Win32 API, thus does not work on
+		// Unix-like OS. For those platforms, use MemoryStreamCreator instead.
+		static readonly bool IS_UNIX;
+
+		static PEImage() {
+			// See http://mono-project.com/FAQ:_Technical#Mono_Platforms for platform detection.
+			int p = (int)Environment.OSVersion.Platform;
+			if (p == 4 || p == 6 || p == 128)
+				IS_UNIX = true;
+		}
+
 		static readonly IPEType MemoryLayout = new MemoryPEType();
 		static readonly IPEType FileLayout = new FilePEType();
 
@@ -177,6 +188,13 @@ namespace dnlib.PE {
 			}
 		}
 
+		static IImageStreamCreator GetFileStreamCreator(string fileName, bool mapAsImage) {
+			if (IS_UNIX)
+				return new MemoryStreamCreator(File.ReadAllBytes(fileName)) { FileName = fileName };
+			else
+				return new MemoryMappedFileStreamCreator(fileName, mapAsImage);
+		}
+
 		/// <summary>
 		/// Constructor
 		/// </summary>
@@ -184,9 +202,9 @@ namespace dnlib.PE {
 		/// <param name="mapAsImage"><c>true</c> if we should map it as an executable</param>
 		/// <param name="verify">Verify PE file data</param>
 		public PEImage(string fileName, bool mapAsImage, bool verify)
-			: this(new MemoryMappedFileStreamCreator(fileName, mapAsImage), mapAsImage ? ImageLayout.Memory : ImageLayout.File, verify) {
+			: this(GetFileStreamCreator(fileName, mapAsImage), mapAsImage ? ImageLayout.Memory : ImageLayout.File, verify) {
 			try {
-				if (mapAsImage) {
+				if (!IS_UNIX && mapAsImage) {
 					((MemoryMappedFileStreamCreator)imageStreamCreator).Length = peInfo.GetImageSize();
 					ResetReader();
 				}


### PR DESCRIPTION
MemoryMappedFileStreamCreator uses WinAPI and thus not working in other OS using Mono. In other OS, it should either use native OS API or fall back to use MemoryStreamCreator.
