### PR TITLE
Fix not handling Retargetable and ContentType in assembly names

### DIFF
--- a/src/DotNet/AssemblyDef.cs
+++ b/src/DotNet/AssemblyDef.cs
@@ -631,7 +631,7 @@ namespace dnlib.DotNet {
 		}
 
 		string GetFullName(PublicKeyBase pkBase) {
-			return Utils.GetAssemblyNameString(name, version, culture, pkBase);
+			return Utils.GetAssemblyNameString(name, version, culture, pkBase, Attributes);
 		}
 
 		/// <summary>

--- a/src/DotNet/AssemblyNameInfo.cs
+++ b/src/DotNet/AssemblyNameInfo.cs
@@ -119,7 +119,7 @@ namespace dnlib.DotNet {
 				var pk = publicKeyOrToken;
 				if (pk is PublicKey)
 					pk = (pk as PublicKey).Token;
-				return Utils.GetAssemblyNameString(name, version, culture, pk);
+				return Utils.GetAssemblyNameString(name, version, culture, pk, flags);
 			}
 		}
 

--- a/src/DotNet/AssemblyRef.cs
+++ b/src/DotNet/AssemblyRef.cs
@@ -182,14 +182,14 @@ namespace dnlib.DotNet {
 		/// Same as <see cref="FullName"/>, except that it uses the <c>PublicKey</c> if available.
 		/// </summary>
 		public string RealFullName {
-			get { return Utils.GetAssemblyNameString(name, version, culture, publicKeyOrToken); }
+			get { return Utils.GetAssemblyNameString(name, version, culture, publicKeyOrToken, Attributes); }
 		}
 
 		/// <summary>
 		/// Gets the full name of the assembly but use a public key token
 		/// </summary>
 		public string FullNameToken {
-			get { return Utils.GetAssemblyNameString(name, version, culture, PublicKeyBase.ToPublicKeyToken(publicKeyOrToken)); }
+			get { return Utils.GetAssemblyNameString(name, version, culture, PublicKeyBase.ToPublicKeyToken(publicKeyOrToken), Attributes); }
 		}
 
 		/// <summary>

--- a/src/DotNet/FullNameCreator.cs
+++ b/src/DotNet/FullNameCreator.cs
@@ -1413,7 +1413,7 @@ namespace dnlib.DotNet {
 			var pk = assembly.PublicKeyOrToken;
 			if (pk is PublicKey)
 				pk = ((PublicKey)pk).Token;
-			return Utils.GetAssemblyNameString(EscapeAssemblyName(assembly.Name), assembly.Version, assembly.Culture, pk);
+			return Utils.GetAssemblyNameString(EscapeAssemblyName(assembly.Name), assembly.Version, assembly.Culture, pk, assembly.Attributes);
 		}
 
 		static string EscapeAssemblyName(UTF8String asmSimplName) {
@@ -1459,7 +1459,7 @@ namespace dnlib.DotNet {
 				var pkt = assembly.PublicKeyOrToken;
 				if (pkt is PublicKey)
 					pkt = ((PublicKey)pkt).Token;
-				sb.Append(Utils.GetAssemblyNameString(assembly.Name, assembly.Version, assembly.Culture, pkt));
+				sb.Append(Utils.GetAssemblyNameString(assembly.Name, assembly.Version, assembly.Culture, pkt, assembly.Attributes));
 			}
 		}
 

--- a/src/DotNet/TypeNameParser.cs
+++ b/src/DotNet/TypeNameParser.cs
@@ -787,21 +787,38 @@ namespace dnlib.DotNet {
 					asmRef.Version = Utils.ParseVersion(value);
 					break;
 
+				case "CONTENTTYPE":
+					if (value.Equals("WindowsRuntime", StringComparison.OrdinalIgnoreCase))
+						asmRef.ContentType = AssemblyAttributes.ContentType_WindowsRuntime;
+					else
+						asmRef.ContentType = AssemblyAttributes.ContentType_Default;
+					break;
+
+				case "RETARGETABLE":
+					if (value.Equals("Yes", StringComparison.OrdinalIgnoreCase))
+						asmRef.IsRetargetable = true;
+					else
+						asmRef.IsRetargetable = false;
+					break;
+
 				case "PUBLICKEY":
-					if (value.Equals("null", StringComparison.OrdinalIgnoreCase))
+					if (value.Equals("null", StringComparison.OrdinalIgnoreCase) ||
+						value.Equals("neutral", StringComparison.OrdinalIgnoreCase))
 						asmRef.PublicKeyOrToken = new PublicKey();
 					else
 						asmRef.PublicKeyOrToken = PublicKeyBase.CreatePublicKey(Utils.ParseBytes(value));
 					break;
 
 				case "PUBLICKEYTOKEN":
-					if (value.Equals("null", StringComparison.OrdinalIgnoreCase))
+					if (value.Equals("null", StringComparison.OrdinalIgnoreCase) ||
+						value.Equals("neutral", StringComparison.OrdinalIgnoreCase))
 						asmRef.PublicKeyOrToken = new PublicKeyToken();
 					else
 						asmRef.PublicKeyOrToken = PublicKeyBase.CreatePublicKeyToken(Utils.ParseBytes(value));
 					break;
 
 				case "CULTURE":
+				case "LANGUAGE":
 					if (value.Equals("neutral", StringComparison.OrdinalIgnoreCase))
 						asmRef.Culture = UTF8String.Empty;
 					else

--- a/src/DotNet/Utils.cs
+++ b/src/DotNet/Utils.cs
@@ -56,8 +56,9 @@ namespace dnlib.DotNet {
 		/// <param name="version">Version or <c>null</c></param>
 		/// <param name="culture">Culture or <c>null</c></param>
 		/// <param name="publicKey">Public key / public key token or <c>null</c></param>
+		/// <param name="attributes">Assembly attributes</param>
 		/// <returns>An assembly name string</returns>
-		internal static string GetAssemblyNameString(UTF8String name, Version version, UTF8String culture, PublicKeyBase publicKey) {
+		internal static string GetAssemblyNameString(UTF8String name, Version version, UTF8String culture, PublicKeyBase publicKey, AssemblyAttributes attributes) {
 			var sb = new StringBuilder();
 			sb.Append(UTF8String.ToSystemStringOrEmpty(name));
 
@@ -74,6 +75,14 @@ namespace dnlib.DotNet {
 			sb.Append(", ");
 			sb.Append(publicKey == null || publicKey is PublicKeyToken ? "PublicKeyToken=" : "PublicKey=");
 			sb.Append(publicKey == null ? "null" : publicKey.ToString());
+
+			if ((attributes & AssemblyAttributes.Retargetable) != 0) {
+				sb.Append(", Retargetable=Yes");
+			}
+
+			if ((attributes & AssemblyAttributes.ContentType_Mask) == AssemblyAttributes.ContentType_WindowsRuntime) {
+				sb.Append(", ContentType=WindowsRuntime");
+			}
 
 			return sb.ToString();
 		}


### PR DESCRIPTION
Some properties are missing (i.e. Retargetable & ContentType) when parsing and writing assembly name. Fixed using [Roslyn](http://source.roslyn.codeplex.com/Microsoft.CodeAnalysis/MetadataReference/AssemblyIdentity.DisplayName.cs.html) as reference.
