### PR TITLE
Fixed issue where the first type was always recognized as the global …

### DIFF
--- a/src/DotNet/ModuleDef.cs
+++ b/src/DotNet/ModuleDef.cs
@@ -467,9 +467,20 @@ namespace dnlib.DotNet {
 		/// <summary>
 		/// Gets the global (aka. &lt;Module&gt;) type or <c>null</c> if there are no types
 		/// </summary>
-		public TypeDef GlobalType {
-			get { return Types.Get(0, null); }
-		}
+        public TypeDef GlobalType {
+            get {
+                var globalType = Types.Get(0, null);
+
+                // The global type shouldn't have a namespace or a base type. If this is the case, the real global type was most likely stripped
+                // during prior obfuscation, so we return null here.
+                if (globalType.Namespace.Length > 0 && globalType.BaseType != null)
+                {
+                    return null;
+                }
+
+                return globalType;
+            }
+        }
 
 		/// <summary>
 		/// Gets/sets the Win32 resources


### PR DESCRIPTION
…type. Not entirely about the detection method, but should do it. For assemblies where <Module> and other stuff is stripped, I had to add this to get Confuser to resolve properly. Nice project btw. - LMS