### PR TITLE
DynamicBodyReader did not update method parameters which lead to wron…

### DIFF
--- a/src/DotNet/Emit/DynamicMethodBodyReader.cs
+++ b/src/DotNet/Emit/DynamicMethodBodyReader.cs
@@ -223,6 +223,7 @@ namespace dnlib.DotNet.Emit {
 			else
 				method.Signature = MethodSig.CreateInstance(retType, pms.ToArray());
 
+			method.Parameters.UpdateParameterTypes();
 			method.ImplAttributes = MethodImplAttributes.IL;
 			method.Attributes = MethodAttributes.PrivateScope;
 			if (isStatic)


### PR DESCRIPTION
…g body generation in some cases. Like starg_1 on .Read() appeared as starg null.