### PR TITLE
Removed check for empty body inside WriteMethodBodies

### DIFF
--- a/src/DotNet/Writer/MetaData.cs
+++ b/src/DotNet/Writer/MetaData.cs
@@ -1545,8 +1545,6 @@ namespace dnlib.DotNet.Writer {
 
 					var cilBody = method.Body;
 					if (cilBody != null) {
-						if (cilBody.Instructions.Count == 0 && cilBody.Variables.Count == 0)
-							continue;
 						var writer = new MethodBodyWriter(this, cilBody, keepMaxStack || cilBody.KeepOldMaxStack);
 						writer.Write();
 						var mb = methodBodies.Add(new MethodBody(writer.Code, writer.ExtraSections, writer.LocalVarSigTok));


### PR DESCRIPTION
Hi,
can I ask you what's the rationale behind this check? I've run into troubles because of that.
There are obfuscators (like ConfuserEx with "anti-tamper" protection) that replace bodies of methods on the fly after decrypting them, so even if bodies may appear empty it's important to save all the information related to bodies, in order to let these application to run correctly.

Thanks,
Marco