### PR TITLE
Assembly Signing is not supported.

### DIFF
--- a/src/dnlib.netstandard.csproj
+++ b/src/dnlib.netstandard.csproj
@@ -4,8 +4,6 @@
         <RootNamespace>dnlib</RootNamespace>
         <AssemblyName>dnlib</AssemblyName>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <SignAssembly>true</SignAssembly>
-        <AssemblyOriginatorKeyFile>..\dnlib.snk</AssemblyOriginatorKeyFile>
         <OutputPath>..\$(Configuration)\bin</OutputPath>
         <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/dnlib.netstandard.csproj
+++ b/src/dnlib.netstandard.csproj
@@ -1,9 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <RootNamespace>dnlib</RootNamespace>
         <AssemblyName>dnlib</AssemblyName>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>..\dnlib.snk</AssemblyOriginatorKeyFile>
+        <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
         <OutputPath>..\$(Configuration)\bin</OutputPath>
         <DocumentationFile>$(OutputPath)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
Assembly signing is only supported on Windows with msbuild.

doesn't build on Linux with signing.
`dotnet build dnlib.netstandard.csproj` output
`CSC : error CS7027: Error signing output with public key from file '../dnlib.snk' -- Assembly signing not supported. [.../dnlib/src/dnlib.netstandard.csproj]`