### PR TITLE
Target both .NET Fx 3.5 and .NET Std 2.0 in dnlib.netstandard.csproj (closes #177)

### DIFF
--- a/src/dnlib.netstandard.csproj
+++ b/src/dnlib.netstandard.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(SolutionDir)\DnlibCommon.props" Condition="Exists('$(SolutionDir)\DnlibCommon.props')" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net35;netstandard2.0</TargetFrameworks>
     <RootNamespace>dnlib</RootNamespace>
     <AssemblyName>dnlib</AssemblyName>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -16,11 +16,11 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <Compile Remove="DefaultDllImportSearchPathsAttribute.cs"/>
     <Compile Remove="HandleProcessCorruptedStateExceptionsAttribute.cs"/>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
This change makes it so that the dnlib.netstandard.csproj file produces both .NET 3.5 and .NET Standard 2.0 binaries, and technically makes the original csproj obsolete (you need VS2017 for C# 7.2 anyway). This change also allows you to easily create a NuGet package on build that includes both versions using this csproj.

See issue #177. Also note that this isn't the Client version of .NET 3.5.

To build the .NET Standard version with .NET Core, use `dotnet build dnlib.netstandard.csproj -f netstandard2.0` now instead of `dotnet build dnlib.netstandard.csproj`.