### PR TITLE
.NET Core: 'AppDomain' does not contain a definition for 'DefineDynamicAssembly'

### DIFF
--- a/src/DotNet/Emit/MethodTableToTypeConverter.cs
+++ b/src/DotNet/Emit/MethodTableToTypeConverter.cs
@@ -27,7 +27,7 @@ namespace dnlib.DotNet.Emit {
 
 		static MethodTableToTypeConverter() {
 			if (ptrFieldInfo == null) {
-#if NETSTANDARD2_0 || NETCOREAPP
+#if NETSTANDARD2_0 || NETCOREAPP2_0
 				var asmb = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("DynAsm"), AssemblyBuilderAccess.Run);
 #else
 				var asmb = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("DynAsm"), AssemblyBuilderAccess.Run);

--- a/src/PE/ProcessorArchUtils.cs
+++ b/src/PE/ProcessorArchUtils.cs
@@ -16,7 +16,7 @@ namespace dnlib.PE {
 		}
 
 		static class RuntimeInformationUtils {
-#if NETSTANDARD2_0 || NETCOREAPP
+#if NETSTANDARD2_0 || NETCOREAPP2_0
 			public static bool TryGet_RuntimeInformation_Architecture(out Machine machine) =>
 				TryGetArchitecture((int)RuntimeInformation.ProcessArchitecture, out machine);
 #else


### PR DESCRIPTION
After a fresh clone, Visual Studio fails to build dnlib: `'AppDomain' does not contain a definition for 'DefineDynamicAssembly' and no accessible extension method 'DefineDynamicAssembly' accepting a first argument of type 'AppDomain' could be found (are you missing a using directive or an assembly reference?)` [MethodTableToTypeConverter.cs:33](https://github.com/0xd4d/dnlib/blob/6a52e50333486af740f098735dd39c0876e1fbee/src/DotNet/Emit/MethodTableToTypeConverter.cs#L33).

I think this was introduced in [this change](https://github.com/0xd4d/dnlib/commit/e4fe68d5b4d5776f1f8e737b88ee092f5df83040#diff-db76fc2e460c8d153e19af074d213089L30). [According to the docs](https://docs.microsoft.com/en-us/dotnet/standard/frameworks), the preprocessor directive to use is `NETCOREAPP2_0`, and indeed changing both occurrences of `NETCOREAPP` with `NETCOREAPP2_0` allows it to build.