### PR TITLE
avoid throwing exception when parsing invalid CustomMarshaler attribute

### DIFF
--- a/src/DotNet/MarshalBlobReader.cs
+++ b/src/DotNet/MarshalBlobReader.cs
@@ -108,7 +108,7 @@ namespace dnlib.DotNet {
 					var guid = ReadUTF8String();
 					var nativeTypeName = ReadUTF8String();
 					var custMarshalerName = ReadUTF8String();
-					var cmRef = TypeNameParser.ParseReflection(module, UTF8String.ToSystemStringOrEmpty(custMarshalerName), new CAAssemblyRefFinder(module), gpContext);
+					var cmRef = custMarshalerName.DataLength == 0 ? null : TypeNameParser.ParseReflection(module, UTF8String.ToSystemStringOrEmpty(custMarshalerName), new CAAssemblyRefFinder(module), gpContext);
 					var cookie = ReadUTF8String();
 					returnValue = new CustomMarshalType(guid, nativeTypeName, cmRef, cookie);
 					break;


### PR DESCRIPTION
I came across some older auto-generated COM wrappers with parameter annotations like below:

`[return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalType = "", MarshalTypeRef = typeof(EnumeratorToEnumVariantMarshaler))]`

This is obviously wrong, but all compilers I tested so far swallow this and generate Marshal Blob with empty strings for both MarshalType and MarshalTypeRef.
dnlib will load such assembly, but will throw `TypeNameParserException` when parsing parameter's MarshalType. 

Mono.Cecil will not throw in this case and will return empty string for MarshalType and null for MarshalTypeRef. I suggest the same behavior for dnlib.
