### PR TITLE
remap types in dnlib.DotNet.Importer

### DIFF
--- a/src/DotNet/Importer.cs
+++ b/src/DotNet/Importer.cs
@@ -775,7 +775,7 @@ namespace dnlib.DotNet {
 			return result;
 		}
 
-		ITypeDefOrRef Import(ITypeDefOrRef type) => (ITypeDefOrRef)Import((IType)type);
+		public ITypeDefOrRef Import(ITypeDefOrRef type) => (ITypeDefOrRef)Import((IType)type);
 
 		TypeSig CreateClassOrValueType(ITypeDefOrRef type, bool isValueType) {
 			var corLibType = module.CorLibTypes.GetCorLibTypeSig(type);

--- a/src/DotNet/Pdb/WindowsPdb/WindowsPdbWriter.cs
+++ b/src/DotNet/Pdb/WindowsPdb/WindowsPdbWriter.cs
@@ -320,7 +320,7 @@ namespace dnlib.DotNet.Pdb.WindowsPdb {
 					return;
 				}
 				if (stepInfo.BreakpointMethod == null) {
-					Error("BreakpointInstruction is null");
+					Error("BreakpointMethod is null");
 					return;
 				}
 				if (stepInfo.BreakpointInstruction == null) {


### PR DESCRIPTION
I'm writing assembly processing library backed by dnlib and suggest a simple improvement to the dnlib.DotNet.Importer for the cases when the imported entity references renamed types in the target module. For example, type A has been imported into target assembly as A_1. 
Now, when processing a reference to A, Importer needs a way to remap the reference to A_1.