### PR TITLE
GetCachedAssemblies function in AssemblyResolver

### DIFF
--- a/src/DotNet/AssemblyResolver.cs
+++ b/src/DotNet/AssemblyResolver.cs
@@ -365,6 +365,12 @@ namespace dnlib.DotNet {
 			}
 		}
 
+		/// <summary>
+		/// Gets the cached assemblies in this resolver.
+		/// </summary>
+		/// <returns>The cached assemblies.</returns>
+		public IEnumerable<AssemblyDef> GetCachedAssemblies() => cachedAssemblies.Values;
+
 		static string GetAssemblyNameKey(IAssembly asmName) {
 			// Make sure the name contains PublicKeyToken= and not PublicKey=
 			return asmName.FullNameToken;


### PR DESCRIPTION
The `dnlib.DotNet.AssemblyResolver` class has a new method called `GetCachedAssemblies` that allows access to the list of assemblies that are currently cached in the resolver.