### PR TITLE
Allow overwriting of the dll name which should be imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Exporting managed methods (DllExport)
 -------------------------------------
 
 dnlib supports exporting managed methods so the managed DLL file can be loaded by native code and then executed. .NET Framework supports this feature, but there's no guarantee that other CLRs (eg. .NET Core or Mono/Unity) support this feature.
+In case of .NET Core please be aware that `ijwhost.dll` has to be loaded prior to calling your exported method and that ijwhost currently (as of .NET Core 3.0) does not work if the calling app is self-contained.
 
 The `MethodDef` class has an `ExportInfo` property. If it gets initialized, the method gets exported when saving the module. At most 65536 (2^16) methods can be exported. This is a PE file limitation, not a dnlib limitation.
 

--- a/src/DotNet/Writer/ImportDirectory.cs
+++ b/src/DotNet/Writer/ImportDirectory.cs
@@ -16,7 +16,7 @@ namespace dnlib.DotNet.Writer {
 		uint length;
 		RVA importLookupTableRVA;
 		RVA corXxxMainRVA;
-		RVA mscoreeDllRVA;
+		RVA dllToImportRVA;
 		int stringsPadding;
 
 		/// <summary>
@@ -50,6 +50,11 @@ namespace dnlib.DotNet.Writer {
 
 		internal bool Enable { get; set; }
 
+		/// <summary>
+		/// Gets/sets the name of the dll which should be imported.
+		/// </summary>
+		public string DllToImport { get; set; } = "mscoree.dll";
+
 		const uint STRINGS_ALIGNMENT = 16;
 
 		/// <summary>
@@ -71,7 +76,7 @@ namespace dnlib.DotNet.Writer {
 			length += (uint)stringsPadding;
 			corXxxMainRVA = rva + length;
 			length += 0xE;
-			mscoreeDllRVA = rva + length;
+			dllToImportRVA = rva + length;
 			length += 0xC;
 			length++;
 		}
@@ -93,7 +98,7 @@ namespace dnlib.DotNet.Writer {
 			writer.WriteUInt32((uint)importLookupTableRVA);
 			writer.WriteInt32(0);	// DateTimeStamp
 			writer.WriteInt32(0);	// ForwarderChain
-			writer.WriteUInt32((uint)mscoreeDllRVA);	// Name
+			writer.WriteUInt32((uint)dllToImportRVA);	// Name
 			writer.WriteUInt32((uint)ImportAddressTable.RVA);
 			writer.WriteUInt64(0);
 			writer.WriteUInt64(0);
@@ -112,7 +117,7 @@ namespace dnlib.DotNet.Writer {
 			writer.WriteZeroes(stringsPadding);
 			writer.WriteUInt16(0);
 			writer.WriteBytes(Encoding.UTF8.GetBytes(IsExeFile ? "_CorExeMain\0" : "_CorDllMain\0"));
-			writer.WriteBytes(Encoding.UTF8.GetBytes("mscoree.dll\0"));
+			writer.WriteBytes(Encoding.UTF8.GetBytes($"{DllToImport}\0"));
 
 			writer.WriteByte(0);
 		}

--- a/src/DotNet/Writer/ImportDirectory.cs
+++ b/src/DotNet/Writer/ImportDirectory.cs
@@ -18,6 +18,7 @@ namespace dnlib.DotNet.Writer {
 		RVA corXxxMainRVA;
 		RVA dllToImportRVA;
 		int stringsPadding;
+		string dllToImport;
 
 		/// <summary>
 		/// Gets/sets the <see cref="ImportAddressTable"/>
@@ -53,9 +54,13 @@ namespace dnlib.DotNet.Writer {
 		/// <summary>
 		/// Gets/sets the name of the dll which should be imported.
 		/// </summary>
-		public string DllToImport { get; set; } = "mscoree.dll";
+		public string DllToImport {
+			get => dllToImport ?? "mscoree.dll";
+			set => dllToImport = value;
+		}
 
 		const uint STRINGS_ALIGNMENT = 16;
+		const uint ZERO_STRING_TERMINATION = 1;
 
 		/// <summary>
 		/// Constructor
@@ -77,7 +82,7 @@ namespace dnlib.DotNet.Writer {
 			corXxxMainRVA = rva + length;
 			length += 0xE;
 			dllToImportRVA = rva + length;
-			length += 0xC;
+			length += (uint)DllToImport.Length + ZERO_STRING_TERMINATION;
 			length++;
 		}
 


### PR DESCRIPTION
This PR adds the ability to overwrite the dll name being used/imported in `ImportDirectory`.

The purpose/use case for this is that .NET core libraries still have "mscoree.dll" in that section but to enable the DLLExport scenario for .NET core we have to use something different to be able to inject our own host/runtime resolution logic.
I use this technique to replace "mscoree.dll" with "ijwhost.dll". I guess the normal compile of .NET core will, sooner or later, also replace "mscoree.dll" in that place with something else.