### PR TITLE
Add more extension methods

### DIFF
--- a/src/DotNet/ICodedToken.cs
+++ b/src/DotNet/ICodedToken.cs
@@ -585,6 +585,28 @@ namespace dnlib.DotNet {
 
 			return null;
 		}
+
+		/// <summary>
+		/// Gets the normal visible parameters, doesn't include the hidden 'this' parameter
+		/// </summary>
+		/// <param name="method">this</param>
+		/// <returns>The normal visible parameters</returns>
+		public static IList<TypeSig> GetParams(this IMethod method) => method?.MethodSig.GetParams();
+
+		/// <summary>
+		/// Gets the normal visible parameter count, doesn't include the hidden 'this' parameter
+		/// </summary>
+		/// <param name="method">this</param>
+		/// <returns>Normal visible parameter count</returns>
+		public static int GetParamCount(this IMethod method) => method?.MethodSig.GetParamCount() ?? 0;
+
+		/// <summary>
+		/// Gets a normal visible parameter, doesn't include the hidden 'this' parameter
+		/// </summary>
+		/// <param name="method">this</param>
+		/// <param name="index">Normal visible parameter index</param>
+		/// <returns></returns>
+		public static TypeSig GetParam(this IMethod method, int index) => method?.MethodSig?.Params?[index];
 	}
 
 	/// <summary>

--- a/src/DotNet/TypeSig.cs
+++ b/src/DotNet/TypeSig.cs
@@ -437,6 +437,13 @@ namespace dnlib.DotNet {
 		public static string GetNamespace(this TypeSig a) => a is null ? string.Empty : a.Namespace;
 
 		/// <summary>
+		/// Returns the <see cref="ITypeDefOrRef"/> if it is a <see cref="TypeDefOrRefSig"/>.
+		/// </summary>
+		/// <param name="a">this</param>
+		/// <returns>A <see cref="ITypeDefOrRef"/> or <c>null</c> if none found</returns>
+		public static ITypeDefOrRef TryGetTypeDefOrRef(this TypeSig a) => (a.RemovePinnedAndModifiers() as TypeDefOrRefSig)?.TypeDefOrRef;
+
+		/// <summary>
 		/// Returns the <see cref="TypeRef"/> if it is a <see cref="TypeDefOrRefSig"/>.
 		/// </summary>
 		/// <param name="a">this</param>


### PR DESCRIPTION
`MethodDef.Parameters` include a possible hidden 'this' parameter, `MethodDef.ParamDefs` don't include the hidden 'this' parameter, but it's possible not present.

Closes https://github.com/0xd4d/dnlib/issues/326