### PR TITLE
Unescape Type.Name & Type.FullName, fix #370

### DIFF
--- a/src/DotNet/Importer.cs
+++ b/src/DotNet/Importer.cs
@@ -354,7 +354,7 @@ namespace dnlib.DotNet {
 
 		TypeRef CreateTypeRef2(Type type) {
 			if (!type.IsNested)
-				return module.UpdateRowId(new TypeRefUser(module, type.Namespace ?? string.Empty, type.Name ?? string.Empty, CreateScopeReference(type)));
+				return module.UpdateRowId(new TypeRefUser(module, type.Namespace ?? string.Empty, ReflectionExtensions.Unescape(type.Name) ?? string.Empty, CreateScopeReference(type)));
 			type.GetTypeNamespaceAndName_TypeDefOrRef(out var @namespace, out var name);
 			return module.UpdateRowId(new TypeRefUser(module, @namespace ?? string.Empty, name ?? string.Empty, CreateTypeRef2(type.DeclaringType)));
 		}

--- a/src/DotNet/ReflectionExtensions.cs
+++ b/src/DotNet/ReflectionExtensions.cs
@@ -108,7 +108,7 @@ namespace dnlib.DotNet {
 			!(type is null) && !type.HasElementType && (!type.IsGenericType || type.IsGenericTypeDefinition);
 
 		internal static string Unescape(string name) {
-			if (string.IsNullOrEmpty(name) || !name.Contains(@"\"))
+			if (string.IsNullOrEmpty(name) || name.IndexOf('\\') < 0)
 				return name;
 			var sb = new StringBuilder(name.Length);
 			for (int i = 0; i < name.Length; i++) {

--- a/src/DotNet/ReflectionExtensions.cs
+++ b/src/DotNet/ReflectionExtensions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Text;
 
 namespace dnlib.DotNet {
 	/// <summary>
@@ -107,9 +108,31 @@ namespace dnlib.DotNet {
 			!(type is null) && !type.HasElementType && (!type.IsGenericType || type.IsGenericTypeDefinition);
 
 		internal static string Unescape(string name) {
-			if (string.IsNullOrEmpty(name))
+			if (string.IsNullOrEmpty(name) || !name.Contains(@"\"))
 				return name;
-			return name.Replace(@"\,", ",").Replace(@"\+", "+").Replace(@"\&", "&").Replace(@"\*", "*").Replace(@"\[", "[").Replace(@"\]", "]").Replace(@"\\", @"\");
+			var sb = new StringBuilder(name.Length);
+			for (int i = 0; i < name.Length; i++) {
+				if (name[i] == '\\' && i < name.Length - 1 && IsReservedTypeNameChar(name[i + 1]))
+					sb.Append(name[++i]);
+				else
+					sb.Append(name[i]);
+			}
+			return sb.ToString();
+		}
+
+		static bool IsReservedTypeNameChar(char c) {
+			switch (c) {
+			case ',':
+			case '+':
+			case '&':
+			case '*':
+			case '[':
+			case ']':
+			case '\\':
+				return true;
+			default:
+				return false;
+			}
 		}
 	}
 }

--- a/src/DotNet/ReflectionExtensions.cs
+++ b/src/DotNet/ReflectionExtensions.cs
@@ -11,12 +11,12 @@ namespace dnlib.DotNet {
 	static class ReflectionExtensions {
 		public static void GetTypeNamespaceAndName_TypeDefOrRef(this Type type, out string @namespace, out string name) {
 			Debug.Assert(type.IsTypeDef());
-			name = type.Name ?? string.Empty;
+			name = Unescape(type.Name) ?? string.Empty;
 			if (!type.IsNested)
 				@namespace = type.Namespace ?? string.Empty;
 			else {
-				var declTypeFullName = type.DeclaringType.FullName;
-				var typeFullName = type.FullName;
+				var declTypeFullName = Unescape(type.DeclaringType.FullName);
+				var typeFullName = Unescape(type.FullName);
 				if (declTypeFullName.Length + 1 + name.Length == typeFullName.Length)
 					@namespace = string.Empty;
 				else
@@ -105,5 +105,11 @@ namespace dnlib.DotNet {
 		/// <param name="type">this</param>
 		public static bool IsTypeDef(this Type type) =>
 			!(type is null) && !type.HasElementType && (!type.IsGenericType || type.IsGenericTypeDefinition);
+
+		internal static string Unescape(string name) {
+			if (string.IsNullOrEmpty(name))
+				return name;
+			return name.Replace(@"\,", ",").Replace(@"\+", "+").Replace(@"\&", "&").Replace(@"\*", "*").Replace(@"\[", "[").Replace(@"\]", "]").Replace(@"\\", @"\");
+		}
 	}
 }

--- a/src/DotNet/SigComparer.cs
+++ b/src/DotNet/SigComparer.cs
@@ -3160,7 +3160,7 @@ exit: ;
 				}
 			}
 			result = !b.HasElementType &&
-					Equals_TypeNames(a.Name, b.Name) &&
+					Equals_TypeNames(a.Name, ReflectionExtensions.Unescape(b.Name)) &&
 					Equals_TypeNamespaces(a.Namespace, b) &&
 					EnclosingTypeEquals(a.DeclaringType, b.DeclaringType) &&
 					(DontCompareTypeScope || Equals(a.Module, b.Module));
@@ -3214,7 +3214,7 @@ exit: ;
 
 			if (!b.IsTypeDef())
 				result = false;
-			else if (!Equals_TypeNames(a.Name, b.Name) || !Equals_TypeNamespaces(a.Namespace, b))
+			else if (!Equals_TypeNames(a.Name, ReflectionExtensions.Unescape(b.Name)) || !Equals_TypeNamespaces(a.Namespace, b))
 				result = false;
 			else if (!((dta = scope as TypeRef) is null))	// nested type
 				result = Equals(dta, b.DeclaringType);	// Compare enclosing types
@@ -3492,7 +3492,7 @@ exit: ;
 
 			if (!b.IsTypeDef())
 				result = false;
-			else if (!Equals_TypeNames(a.TypeName, b.Name) || !Equals_TypeNamespaces(a.TypeNamespace, b))
+			else if (!Equals_TypeNames(a.TypeName, ReflectionExtensions.Unescape(b.Name)) || !Equals_TypeNamespaces(a.TypeNamespace, b))
 				result = false;
 			else if (!((dta = scope as ExportedType) is null))	// nested type
 				result = Equals(dta, b.DeclaringType);	// Compare enclosing types
@@ -3678,7 +3678,7 @@ exit: ;
 			if (a is null)
 				return GetHashCodeGlobalType();
 			int hash;
-			hash = GetHashCode_TypeName(a.Name);
+			hash = GetHashCode_TypeName(ReflectionExtensions.Unescape(a.Name));
 			if (a.IsNested)
 				hash += HASHCODE_MAGIC_NESTED_TYPE;
 			else


### PR DESCRIPTION
No need to unescape Type.Namespace.
This PR can fix #370