### PR TITLE
'=' is not an special char for TypeName

### DIFF
--- a/src/DotNet/TypeNameParser.cs
+++ b/src/DotNet/TypeNameParser.cs
@@ -841,7 +841,6 @@ namespace dnlib.DotNet {
 			case '*':
 			case '[':
 			case ']':
-			case '=':
 				return -1;
 
 			default:


### PR DESCRIPTION
Align with the logic in `FullNameFactory.AddIdentifier(string)` and `ReflectionExtensions.IsReservedTypeNameChar(char)` in dnlib and `ResourceRenamer.IsReservedTypeNameChar(char)` in de4dot