### PR TITLE
ResolutionScope now actually can be null/0 in .NET 5 reference assemblies

### DIFF
--- a/src/DotNet/Writer/Metadata.cs
+++ b/src/DotNet/Writer/Metadata.cs
@@ -2325,7 +2325,6 @@ namespace dnlib.DotNet.Writer {
 		/// <returns>Its encoded token</returns>
 		protected uint AddResolutionScope(IResolutionScope rs) {
 			if (rs is null) {
-				// ResolutionScope can now actually be null in .NET 5 Reference Assemblies, so do not throw error any longer here, just return 0
 				return 0;
 			}
 

--- a/src/DotNet/Writer/Metadata.cs
+++ b/src/DotNet/Writer/Metadata.cs
@@ -2325,7 +2325,7 @@ namespace dnlib.DotNet.Writer {
 		/// <returns>Its encoded token</returns>
 		protected uint AddResolutionScope(IResolutionScope rs) {
 			if (rs is null) {
-				Error("ResolutionScope is null");
+				// ResolutionScope can now actually be null in .NET 5 Reference Assemblies, so do not throw error any longer here, just return 0
 				return 0;
 			}
 


### PR DESCRIPTION
Guess what I found out:
ResolutionScope now actually can be null/0 in .NET 5 reference assemblies, so the solution is to not throw an error and just return 0.
If you want to see this at work just build the attached project and try to rewrite the reference assembly (the one in the /ref subfolder) with this module, it will fail with error message "dnlib.DotNet.Writer.ModuleWriterException: ResolutionScope is null" though everything would be correct if we just return 0 (which is, after all, also what was read in).
I don't know if other properties of MetaData could be affected too, but that's what we experienced so far.
[TestProject.zip](https://github.com/0xd4d/dnlib/files/6799054/TestProject.zip)
Thanks so much for unarchiving the repository for this Pull Request! :)