### PR TITLE
Preserve Log2Rid value when rewriting a module.

### DIFF
--- a/src/DotNet/Writer/ModuleWriterBase.cs
+++ b/src/DotNet/Writer/ModuleWriterBase.cs
@@ -113,28 +113,28 @@ namespace dnlib.DotNet.Writer {
 		/// Don't use Microsoft.DiaSymReader.Native. This is a NuGet package with an updated Windows PDB reader/writer implementation,
 		/// and if it's available at runtime, dnlib will try to use it. If this option is set, dnlib won't use it.
 		/// You have to add a reference to the NuGet package if you want to use it, dnlib has no reference to the NuGet package.
-		/// 
+		///
 		/// This is only used if it's a Windows PDB file.
 		/// </summary>
 		NoDiaSymReader			= 0x00000001,
 
 		/// <summary>
 		/// Don't use diasymreader.dll's PDB writer that is shipped with .NET Framework.
-		/// 
+		///
 		/// This is only used if it's a Windows PDB file.
 		/// </summary>
 		NoOldDiaSymReader		= 0x00000002,
 
 		/// <summary>
 		/// Create a deterministic PDB file and add a <see cref="ImageDebugType.Reproducible"/> debug directory entry to the PE file.
-		/// 
+		///
 		/// It's ignored if the PDB writer doesn't support it.
 		/// </summary>
 		Deterministic			= 0x00000004,
 
 		/// <summary>
 		/// Hash the PDB file and add a PDB checksum debug directory entry to the PE file.
-		/// 
+		///
 		/// It's ignored if the PDB writer doesn't support it.
 		/// </summary>
 		PdbChecksum				= 0x00000008,
@@ -382,6 +382,10 @@ namespace dnlib.DotNet.Writer {
 			else {
 				Cor20HeaderOptions.MajorRuntimeVersion = 2;
 				Cor20HeaderOptions.MinorRuntimeVersion = 5;
+			}
+
+			if (module is ModuleDefMD moduleDefMd) {
+				MetadataOptions.TablesHeapOptions.Log2Rid = moduleDefMd.TablesStream.Log2Rid;
 			}
 
 			if (module.TablesHeaderVersion is not null) {

--- a/src/DotNet/Writer/ModuleWriterBase.cs
+++ b/src/DotNet/Writer/ModuleWriterBase.cs
@@ -384,10 +384,6 @@ namespace dnlib.DotNet.Writer {
 				Cor20HeaderOptions.MinorRuntimeVersion = 5;
 			}
 
-			if (module is ModuleDefMD moduleDefMd) {
-				MetadataOptions.TablesHeapOptions.Log2Rid = moduleDefMd.TablesStream.Log2Rid;
-			}
-
 			if (module.TablesHeaderVersion is not null) {
 				MetadataOptions.TablesHeapOptions.MajorVersion = (byte)(module.TablesHeaderVersion.Value >> 8);
 				MetadataOptions.TablesHeapOptions.MinorVersion = (byte)module.TablesHeaderVersion.Value;
@@ -428,6 +424,7 @@ namespace dnlib.DotNet.Writer {
 					PdbOptions |= PdbWriterOptions.PdbChecksum;
 				if (TryGetPdbChecksumAlgorithm(modDefMD.Metadata.PEImage, modDefMD.Metadata.PEImage.ImageDebugDirectories, out var pdbChecksumAlgorithm))
 					PdbChecksumAlgorithm = pdbChecksumAlgorithm;
+				MetadataOptions.TablesHeapOptions.Log2Rid = modDefMD.TablesStream.Log2Rid;
 			}
 
 			if (Is64Bit) {

--- a/src/DotNet/Writer/TablesHeap.cs
+++ b/src/DotNet/Writer/TablesHeap.cs
@@ -40,6 +40,11 @@ namespace dnlib.DotNet.Writer {
 		public uint? ExtraData;
 
 		/// <summary>
+		/// Log2Rid to write
+		/// </summary>
+		public byte? Log2Rid;
+
+		/// <summary>
 		/// <c>true</c> if there are deleted <see cref="TypeDef"/>s, <see cref="ExportedType"/>s,
 		/// <see cref="FieldDef"/>s, <see cref="MethodDef"/>s, <see cref="EventDef"/>s and/or
 		/// <see cref="PropertyDef"/>s.
@@ -57,6 +62,7 @@ namespace dnlib.DotNet.Writer {
 				MinorVersion = 0,
 				UseENC = null,
 				ExtraData = null,
+				Log2Rid = null,
 				HasDeletedRows = null,
 			};
 	}
@@ -469,7 +475,7 @@ namespace dnlib.DotNet.Writer {
 
 		byte GetLog2Rid() {
 			//TODO: Sometimes this is 16. Probably when at least one of the table indexes requires 4 bytes.
-			return 1;
+			return options.Log2Rid ?? 1;
 		}
 
 		ulong GetValidMask() {


### PR DESCRIPTION
Also allows for the user to specify the value.

Can be used to bypass an anti-tampering check in which the obfuscator writes a different value than `1` and then checks at runtime if it is what it wrote.