### PR TITLE
Add support for reading V1 resources

### DIFF
--- a/src/DotNet/Resources/ResourceReader.cs
+++ b/src/DotNet/Resources/ResourceReader.cs
@@ -201,7 +201,8 @@ namespace dnlib.DotNet.Resources {
 			if (typeIndex < 0 || typeIndex >= userTypes.Count)
 				throw new ResourceReaderException($"Invalid resource type index: {typeIndex}");
 			var type = userTypes[typeIndex];
-			switch (type.Name) {
+			var actualName = type.Name.Split(',')[0];
+			switch (actualName) {
 			case "System.String":   return resourceDataFactory.Create(reader.ReadSerializedString());
 			case "System.Int32":    return resourceDataFactory.Create(reader.ReadInt32());
 			case "System.Byte":     return resourceDataFactory.Create(reader.ReadByte());
@@ -258,7 +259,7 @@ namespace dnlib.DotNet.Resources {
 			for (int i = 0; i < numReaders; i++) {
 				var resourceReaderFullName = reader.ReadSerializedString();
 				/*var resourceSetFullName = */reader.ReadSerializedString();
-				if (Regex.IsMatch(resourceReaderFullName, @"^System\.Resources\.ResourceReader,\s*mscorlib,"))
+				if (Regex.IsMatch(resourceReaderFullName, @"^System\.Resources\.ResourceReader,\s*mscorlib"))
 					validReader = true;
 			}
 

--- a/src/DotNet/Resources/ResourceReader.cs
+++ b/src/DotNet/Resources/ResourceReader.cs
@@ -201,7 +201,8 @@ namespace dnlib.DotNet.Resources {
 			if (typeIndex < 0 || typeIndex >= userTypes.Count)
 				throw new ResourceReaderException($"Invalid resource type index: {typeIndex}");
 			var type = userTypes[typeIndex];
-			var actualName = type.Name.Split(',')[0];
+			var commaIndex = type.Name.IndexOf(',');
+			string actualName = commaIndex == -1 ? type.Name : type.Name.Remove(commaIndex);
 			switch (actualName) {
 			case "System.String":   return resourceDataFactory.Create(reader.ReadSerializedString());
 			case "System.Int32":    return resourceDataFactory.Create(reader.ReadInt32());

--- a/src/DotNet/Resources/ResourceReader.cs
+++ b/src/DotNet/Resources/ResourceReader.cs
@@ -98,7 +98,7 @@ namespace dnlib.DotNet.Resources {
 			if (!CheckReaders())
 				throw new ResourceReaderException("Invalid resource reader");
 			int version = reader.ReadInt32();
-			if (version != 2)//TODO: Support version 1
+			if (version != 2 && version != 1)
 				throw new ResourceReaderException($"Invalid resource version: {version}");
 			int numResources = reader.ReadInt32();
 			if (numResources < 0)
@@ -141,7 +141,8 @@ namespace dnlib.DotNet.Resources {
 				reader.Position = (uint)info.offset;
 				long nextDataOffset = i == infos.Count - 1 ? end : infos[i + 1].offset;
 				int size = (int)(nextDataOffset - info.offset);
-				element.ResourceData = ReadResourceData(userTypes, size);
+				element.ResourceData =
+					version == 1 ? ReadResourceDataV1(userTypes, size) : ReadResourceDataV2(userTypes, size);
 				element.ResourceData.StartOffset = baseFileOffset + (FileOffset)info.offset;
 				element.ResourceData.EndOffset = baseFileOffset + (FileOffset)reader.Position;
 
@@ -161,7 +162,7 @@ namespace dnlib.DotNet.Resources {
 			public override string ToString() => $"{offset:X8} - {name}";
 		}
 
-		IResourceData ReadResourceData(List<UserResourceType> userTypes, int size) {
+		IResourceData ReadResourceDataV2(List<UserResourceType> userTypes, int size) {
 			uint endPos = reader.Position + (uint)size;
 			uint code = ReadUInt32(ref reader);
 			switch ((ResourceTypeCode)code) {
@@ -196,6 +197,50 @@ namespace dnlib.DotNet.Resources {
 						return res;
 				}
 				return resourceDataFactory.CreateSerialized(serializedData, userType);
+			}
+		}
+
+		IResourceData ReadResourceDataV1(List<UserResourceType> userTypes, int size) {
+			uint endPos = reader.Position + (uint)size;
+			int typeIndex = ReadInt32(ref reader);
+			if (typeIndex == -1) {
+				return resourceDataFactory.CreateNull();
+			}
+			if (typeIndex < 0 || typeIndex >= userTypes.Count)
+				throw new ResourceReaderException($"Invalid resource type index: {typeIndex}");
+			var type = userTypes[typeIndex];
+			switch (type.Name) {
+			case "System.String":   return resourceDataFactory.Create(reader.ReadSerializedString());
+			case "System.Int32":    return resourceDataFactory.Create(reader.ReadInt32());
+			case "System.Byte":     return resourceDataFactory.Create(reader.ReadByte());
+			case "System.SByte":    return resourceDataFactory.Create(reader.ReadSByte());
+			case "System.Int16":    return resourceDataFactory.Create(reader.ReadInt16());
+			case "System.Int64":    return resourceDataFactory.Create(reader.ReadInt64());
+			case "System.UInt16":   return resourceDataFactory.Create(reader.ReadUInt16());
+			case "System.UInt32":   return resourceDataFactory.Create(reader.ReadUInt32());
+			case "System.UInt64":   return resourceDataFactory.Create(reader.ReadUInt64());
+			case "System.Single":   return resourceDataFactory.Create(reader.ReadSingle());
+			case "System.Double":   return resourceDataFactory.Create(reader.ReadDouble());
+			case "System.DateTime": return resourceDataFactory.Create(new DateTime(reader.ReadInt64()));
+			case "System.TimeSpan": return resourceDataFactory.Create(new TimeSpan(reader.ReadInt64()));
+			case "System.Decimal":  return resourceDataFactory.Create(reader.ReadDecimal());
+			default:
+				var serializedData = reader.ReadBytes((int)(endPos - reader.Position));
+				if (createResourceDataDelegate is not null) {
+					var res = createResourceDataDelegate(resourceDataFactory, type, serializedData);
+					if (res is not null)
+						return res;
+				}
+				return resourceDataFactory.CreateSerialized(serializedData, type);
+			}
+		}
+
+		static int ReadInt32(ref DataReader reader) {
+			try {
+				return reader.Read7BitEncodedInt32();
+			}
+			catch {
+				throw new ResourceReaderException("Invalid encoded int32");
 			}
 		}
 


### PR DESCRIPTION
Version 1 resources should now be read properly. They are rewritten as version 2 when `ResourceWriter` is used. This code was based on the code in the `ResourceReader` class in `mscorlib` for .NET 2.0. I'm unaware of a way to produce these version 1 resources so I was not able to test this code but since it is pretty much 1:1 to the official implementation I think it's ok.