### PR TITLE
Fixes TypeHelper.ContainsGenericParameter(MethodSpec)

### DIFF
--- a/src/DotNet/TypeHelper.cs
+++ b/src/DotNet/TypeHelper.cs
@@ -13,14 +13,7 @@ namespace dnlib.DotNet {
 		internal static bool ContainsGenericParameter(InterfaceImpl ii) => ii is not null && TypeHelper.ContainsGenericParameter(ii.Interface);
 		internal static bool ContainsGenericParameter(GenericParamConstraint gpc) => gpc is not null && ContainsGenericParameter(gpc.Constraint);
 
-		internal static bool ContainsGenericParameter(MethodSpec ms) {
-			if (ms is null)
-				return false;
-
-			// A normal MethodSpec should always contain generic arguments and thus
-			// its MethodDef is always a generic method with generic parameters.
-			return true;
-		}
+		internal static bool ContainsGenericParameter(MethodSpec ms) => ms is not null && ContainsGenericParameter(ms.GenericInstMethodSig);
 
 		internal static bool ContainsGenericParameter(MemberRef mr) {
 			if (mr is null)


### PR DESCRIPTION
TypeSpec.ContainsGenericParameter should be handled in the same way with MethodSpec.ContainsGenericParameter.
The following code will let debugger break at CheckMethodSpec().
TypeHelper.ContainsGenericParameter(MethodSpec) should not always return true.
``` cs
using System.Diagnostics;
using dnlib.DotNet;

class Program {
	static void Main() {
		var module = ModuleDefMD.Load("dnlib.dll");
		CheckTypeSpec(module);
		CheckMethodSpec(module);

		{
			uint rid = 1;
			MethodSpec ms;
			while ((ms = module.ResolveMethodSpec(rid++)) is not null) {
			}
		}
		{
			uint rid = 1;
			MethodDef md;
			while ((md = module.ResolveMethod(rid++)) is not null) {
				if (!md.HasBody)
					continue;
				foreach (var instr in md.Body.Instructions) {
					if (instr.Operand is MethodSpec ms && ms.GenericInstMethodSig.ContainsGenericParameter)
						Debugger.Break();
				}
			}
		}
	}

	static void CheckTypeSpec(ModuleDefMD module) {
		uint rid = 1;
		TypeSpec ts;
		while ((ts = module.ResolveTypeSpec(rid++)) is not null) {
			if (((IContainsGenericParameter)ts).ContainsGenericParameter != ts.TypeSig.ContainsGenericParameter)
				Debugger.Break();
		}
	}

	static void CheckMethodSpec(ModuleDefMD module) {
		uint rid = 1;
		MethodSpec ms;
		while ((ms = module.ResolveMethodSpec(rid++)) is not null) {
			if (((IContainsGenericParameter)ms).ContainsGenericParameter != ms.GenericInstMethodSig.ContainsGenericParameter)
				Debugger.Break();
		}
	}
}
```