### PR TITLE
Improve Importer TryToUseMethodDefs and TryToUseFieldDefs options 2

### DIFF
--- a/src/DotNet/Importer.cs
+++ b/src/DotNet/Importer.cs
@@ -516,7 +516,7 @@ namespace dnlib.DotNet {
 			}
 		}
 
-		bool IsThisModule(Module module2) => module.Name == module2.Name && IsThisAssembly(module2);
+		bool IsThisModule(Module module2) => UTF8String.ToSystemStringOrEmpty(module.Name).Equals(module2.ScopeName, StringComparison.OrdinalIgnoreCase) && IsThisAssembly(module2);
 
 		MethodSig CreateMethodSig(MethodBase mb) {
 			var sig = new MethodSig(GetCallingConvention(mb));


### PR DESCRIPTION
Obfuscator may rename many methods/fields into same name then TryResolveMethod/TryResolveField will return inconsistent method/field.

Previous PR contains some problems and I fixed it. In previous PR you mentioned 'privatescope' visibility. I check some documents and find it is visible in the same module and can't be referenced in MemberRef table. I think these code won't get error when encountering 'privatescope' visibility. Should it be handled specially?