### PR TITLE
Fix infinite loop in SigComparer.GetHashCode(TypeSig)

### DIFF
--- a/src/DotNet/SigComparer.cs
+++ b/src/DotNet/SigComparer.cs
@@ -2007,8 +2007,11 @@ exit: ;
 				return 0;
 			int hash;
 
-			if (substituteGenericParameters && genericArguments is not null)
+			if (substituteGenericParameters && genericArguments is not null) {
+				var t = a;
 				a = genericArguments.Resolve(a);
+				substituteGenericParameters = t == a;
+			}
 
 			switch (a.ElementType) {
 			case ElementType.Void:
@@ -2078,8 +2081,8 @@ exit: ;
 			case ElementType.GenericInst:
 				var gia = (GenericInstSig)a;
 				hash = HASHCODE_MAGIC_ET_GENERICINST;
-				hash += GetHashCode(gia.GenericType, false);
-				hash += GetHashCode(gia.GenericArguments, false);
+				hash += GetHashCode(gia.GenericType, substituteGenericParameters);
+				hash += GetHashCode(gia.GenericArguments, substituteGenericParameters);
 				break;
 
 			case ElementType.FnPtr:
@@ -2141,7 +2144,7 @@ exit: ;
 		/// </summary>
 		/// <param name="a">The type list</param>
 		/// <returns>The hash code</returns>
-		public int GetHashCode(IList<TypeSig> a) => GetHashCode(a, false);
+		public int GetHashCode(IList<TypeSig> a) => GetHashCode(a, true);
 
 		int GetHashCode(IList<TypeSig> a, bool substituteGenericParameters) {
 			//************************************************************************


### PR DESCRIPTION
1.
Fix https://github.com/0xd4d/dnlib/issues/427
In code:
``` cs
static void Test<T>(Dictionary<T, T> dict) { string.Concat(dict); }
```
MethodSig of 'string.Concat' is 'string (IEnumerable<KeyPairValue<T, T>>)' and dnlib will repeat substitute one of 'T' in 'KeyPairValue<T, T>' with ''KeyPairValue<T, T>'' itself, so there is an infinite loop. I add a parameter to disable substituting when get hash code for 'GenericInstSig.GenericArguments'.

2.
About deleted code:
``` cs
if (SubstituteGenericParameters) {
	InitializeGenericArguments();
	genericArguments.PushTypeArgs(gia.GenericArguments);
	hash += GetHashCode(gia.GenericType);
	genericArguments.PopTypeArgs();
}
```
GenericType is always TypeDef or TypeRef so it makes no sense to substitute generic parameters.