### PR TITLE
fix: correct a wrong flag in IsClass

### DIFF
--- a/src/DotNet/ExportedType.cs
+++ b/src/DotNet/ExportedType.cs
@@ -349,8 +349,8 @@ namespace dnlib.DotNet {
 		/// Gets/sets the <see cref="TypeAttributes.Class"/> bit
 		/// </summary>
 		public bool IsClass {
-			get => ((TypeAttributes)attributes & TypeAttributes.Interface) == 0;
-			set => ModifyAttributes(!value, TypeAttributes.Interface);
+			get => ((TypeAttributes)attributes & TypeAttributes.Class) == 0;
+			set => ModifyAttributes(!value, TypeAttributes.Class);
 		}
 
 		/// <summary>

--- a/src/DotNet/TypeDef.cs
+++ b/src/DotNet/TypeDef.cs
@@ -782,8 +782,8 @@ namespace dnlib.DotNet {
 		/// Gets/sets the <see cref="TypeAttributes.Class"/> bit
 		/// </summary>
 		public bool IsClass {
-			get => ((TypeAttributes)attributes & TypeAttributes.Interface) == 0;
-			set => ModifyAttributes(!value, TypeAttributes.Interface);
+			get => ((TypeAttributes)attributes & TypeAttributes.Class) == 0;
+			set => ModifyAttributes(!value, TypeAttributes.Class);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The old usage of `TypeAttributes.Interface` in `public bool IsClass` is a typo bug.