### PR TITLE
Add support for new Roslyn CustomDebugInfo

### DIFF
--- a/src/DotNet/Pdb/CustomDebugInfoGuids.cs
+++ b/src/DotNet/Pdb/CustomDebugInfoGuids.cs
@@ -20,6 +20,8 @@ namespace dnlib.DotNet.Pdb {
 		public static readonly Guid TupleElementNames = new Guid("ED9FDF71-8879-4747-8ED3-FE5EDE3CE710");
 		public static readonly Guid CompilationMetadataReferences = new Guid("7E4D4708-096E-4C5C-AEDA-CB10BA6A740D");
 		public static readonly Guid CompilationOptions = new Guid("B5FEEC05-8CD0-4A83-96DA-466284BB4BD8");
+		public static readonly Guid TypeDefinitionDocuments = new Guid("932E74BC-DBA9-4478-8D46-0F32A7BAB3D3");
+		public static readonly Guid EncStateMachineStateMap = new Guid("8B78CD68-2EDE-420B-980B-E15884B8AAA3");
 #pragma warning restore 1591 // Missing XML comment for publicly visible type or member
 	}
 }

--- a/src/DotNet/Pdb/Dss/SymbolDocumentImpl.cs
+++ b/src/DotNet/Pdb/Dss/SymbolDocumentImpl.cs
@@ -89,5 +89,7 @@ namespace dnlib.DotNet.Pdb.Dss {
 			}
 		}
 		PdbCustomDebugInfo[] customDebugInfos;
+
+		public override MDToken? MDToken => null;
 	}
 }

--- a/src/DotNet/Pdb/Managed/DbiDocument.cs
+++ b/src/DotNet/Pdb/Managed/DbiDocument.cs
@@ -38,6 +38,8 @@ namespace dnlib.DotNet.Pdb.Managed {
 		}
 		PdbCustomDebugInfo[] customDebugInfos;
 
+		public override MDToken? MDToken => null;
+
 		public DbiDocument(string url) {
 			this.url = url;
 			documentType = SymDocumentType.Text;

--- a/src/DotNet/Pdb/PdbCustomDebugInfo.cs
+++ b/src/DotNet/Pdb/PdbCustomDebugInfo.cs
@@ -1144,15 +1144,17 @@ namespace dnlib.DotNet.Pdb {
 			Interlocked.CompareExchange(ref documents, new List<PdbDocument>(), null);
 	}
 
-	class PdbTypeDefinitionDocumentsDebugInfoMD : PdbTypeDefinitionDocumentsDebugInfo {
+	sealed class PdbTypeDefinitionDocumentsDebugInfoMD : PdbTypeDefinitionDocumentsDebugInfo {
 		readonly ModuleDef readerModule;
 		readonly IList<MDToken> documentTokens;
 
 		protected override void InitializeDocuments() {
 			var list = new List<PdbDocument>(documentTokens.Count);
-			for (var i = 0; i < documentTokens.Count; i++) {
-				if (readerModule.PdbState.tokenToDocument.TryGetValue(documentTokens[i], out var document))
-					list.Add(document);
+			if (readerModule.PdbState is not null) {
+				for (var i = 0; i < documentTokens.Count; i++) {
+					if (readerModule.PdbState.tokenToDocument.TryGetValue(documentTokens[i], out var document))
+						list.Add(document);
+				}
 			}
 			Interlocked.CompareExchange(ref documents, list, null);
 		}

--- a/src/DotNet/Pdb/PdbDocument.cs
+++ b/src/DotNet/Pdb/PdbDocument.cs
@@ -54,6 +54,11 @@ namespace dnlib.DotNet.Pdb {
 		IList<PdbCustomDebugInfo> customDebugInfos;
 
 		/// <summary>
+		/// Gets the Metadata token of the document if available.
+		/// </summary>
+		public MDToken? MDToken { get; internal set; }
+
+		/// <summary>
 		/// Default constructor
 		/// </summary>
 		public PdbDocument() {
@@ -86,6 +91,7 @@ namespace dnlib.DotNet.Pdb {
 			customDebugInfos = new List<PdbCustomDebugInfo>();
 			foreach (var cdi in symDoc.CustomDebugInfos)
 				customDebugInfos.Add(cdi);
+			MDToken = symDoc.MDToken;
 		}
 
 		/// <summary>

--- a/src/DotNet/Pdb/PdbState.cs
+++ b/src/DotNet/Pdb/PdbState.cs
@@ -124,6 +124,8 @@ namespace dnlib.DotNet.Pdb {
 			if (docDict.TryGetValue(doc, out var orig))
 				return orig;
 			docDict.Add(doc, doc);
+			if (doc.MDToken.HasValue)
+				tokenToDocument.Add(doc.MDToken.Value, doc);
 			return doc;
 		}
 
@@ -148,6 +150,8 @@ namespace dnlib.DotNet.Pdb {
 #if THREAD_SAFE
 			theLock.EnterWriteLock(); try {
 #endif
+			if (doc.MDToken.HasValue)
+				tokenToDocument.Remove(doc.MDToken.Value);
 			return docDict.Remove(doc);
 #if THREAD_SAFE
 			} finally { theLock.ExitWriteLock(); }
@@ -189,6 +193,7 @@ namespace dnlib.DotNet.Pdb {
 			theLock.EnterWriteLock(); try {
 #endif
 			var docs = returnDocs ? new List<PdbDocument>(docDict.Values) : null;
+			tokenToDocument.Clear();
 			docDict.Clear();
 			return docs;
 #if THREAD_SAFE

--- a/src/DotNet/Pdb/PdbState.cs
+++ b/src/DotNet/Pdb/PdbState.cs
@@ -15,6 +15,7 @@ namespace dnlib.DotNet.Pdb {
 	public sealed class PdbState {
 		readonly SymbolReader reader;
 		readonly Dictionary<PdbDocument, PdbDocument> docDict = new Dictionary<PdbDocument, PdbDocument>();
+		internal readonly Dictionary<MDToken, PdbDocument> tokenToDocument = new Dictionary<MDToken, PdbDocument>();
 		MethodDef userEntryPoint;
 		readonly Compiler compiler;
 		readonly PdbFileKind originalPdbFileKind;
@@ -64,7 +65,7 @@ namespace dnlib.DotNet.Pdb {
 #if THREAD_SAFE
 				} finally { theLock.ExitWriteLock(); }
 #endif
-		
+
 			}
 		}
 
@@ -133,6 +134,8 @@ namespace dnlib.DotNet.Pdb {
 			// Expensive part, can read source code etc
 			doc.Initialize(symDoc);
 			docDict.Add(doc, doc);
+			if (symDoc.MDToken.HasValue)
+				tokenToDocument.Add(symDoc.MDToken.Value, doc);
 			return doc;
 		}
 

--- a/src/DotNet/Pdb/Portable/PortablePdbCustomDebugInfoReader.cs
+++ b/src/DotNet/Pdb/Portable/PortablePdbCustomDebugInfoReader.cs
@@ -65,6 +65,10 @@ namespace dnlib.DotNet.Pdb.Portable {
 				return ReadCompilationMetadataReferences();
 			if (kind == CustomDebugInfoGuids.CompilationOptions)
 				return ReadCompilationOptions();
+			if (kind == CustomDebugInfoGuids.TypeDefinitionDocuments)
+				return ReadTypeDefinitionDocuments();
+			if (kind == CustomDebugInfoGuids.EncStateMachineStateMap)
+				return ReadEncStateMachineStateMap();
 			Debug.Fail("Unknown custom debug info guid: " + kind.ToString());
 			return new PdbUnknownCustomDebugInfo(kind, reader.ReadRemainingBytes());
 		}
@@ -223,6 +227,35 @@ namespace dnlib.DotNet.Pdb.Portable {
 				if (value is null)
 					break;
 				cdi.Options.Add(new KeyValuePair<string, string>(key, value));
+			}
+
+			return cdi;
+		}
+
+		PdbCustomDebugInfo ReadTypeDefinitionDocuments() {
+			var cdi = new PdbTypeDefinitionDocumentsDebugInfo();
+
+			while (reader.BytesLeft > 0)
+				cdi.DocumentTokens.Add(new MDToken(Table.Document, reader.ReadCompressedUInt32()));
+
+			return cdi;
+		}
+
+		PdbCustomDebugInfo ReadEncStateMachineStateMap() {
+			var cdi = new PdbEditAndContinueStateMachineStateMapDebugInfo();
+
+			var count = reader.ReadCompressedUInt32();
+			if (count > 0) {
+				long syntaxOffsetBaseline = -reader.ReadCompressedUInt32();
+
+				while (count > 0) {
+					int stateNumber = reader.ReadCompressedInt32();
+					int syntaxOffset = (int)(syntaxOffsetBaseline + reader.ReadCompressedUInt32());
+
+					cdi.StateMachineStates.Add(new StateMachineStateInfo(syntaxOffset, (StateMachineState)stateNumber));
+
+					count--;
+				}
 			}
 
 			return cdi;

--- a/src/DotNet/Pdb/Portable/PortablePdbCustomDebugInfoReader.cs
+++ b/src/DotNet/Pdb/Portable/PortablePdbCustomDebugInfoReader.cs
@@ -233,12 +233,11 @@ namespace dnlib.DotNet.Pdb.Portable {
 		}
 
 		PdbCustomDebugInfo ReadTypeDefinitionDocuments() {
-			var cdi = new PdbTypeDefinitionDocumentsDebugInfo();
-
+			var docList = new List<MDToken>();
 			while (reader.BytesLeft > 0)
-				cdi.DocumentTokens.Add(new MDToken(Table.Document, reader.ReadCompressedUInt32()));
+				docList.Add(new MDToken(Table.Document, reader.ReadCompressedUInt32()));
 
-			return cdi;
+			return new PdbTypeDefinitionDocumentsDebugInfoMD(module, docList);
 		}
 
 		PdbCustomDebugInfo ReadEncStateMachineStateMap() {

--- a/src/DotNet/Pdb/Portable/PortablePdbCustomDebugInfoWriter.cs
+++ b/src/DotNet/Pdb/Portable/PortablePdbCustomDebugInfoWriter.cs
@@ -329,8 +329,8 @@ namespace dnlib.DotNet.Pdb.Portable {
 		}
 
 		void WriteTypeDefinitionDocuments(PdbTypeDefinitionDocumentsDebugInfo cdi) {
-			foreach (var docToken in cdi.DocumentTokens)
-				writer.WriteCompressedUInt32(docToken.Rid);
+			foreach (var document in cdi.Documents)
+				writer.WriteCompressedUInt32(systemMetadata.GetRid(document));
 		}
 
 		void WriteEditAndContinueStateMachineStateMap(PdbEditAndContinueStateMachineStateMapDebugInfo cdi) {

--- a/src/DotNet/Pdb/Portable/PortablePdbReader.cs
+++ b/src/DotNet/Pdb/Portable/PortablePdbReader.cs
@@ -61,7 +61,8 @@ namespace dnlib.DotNet.Pdb.Portable {
 			var custInfos = ListCache<PdbCustomDebugInfo>.AllocList();
 			var gpContext = new GenericParamContext();
 			for (int i = 0; i < docs.Length; i++) {
-				bool b = pdbMetadata.TablesStream.TryReadDocumentRow((uint)i + 1, out var row);
+				uint rid = (uint)i + 1;
+				bool b = pdbMetadata.TablesStream.TryReadDocumentRow(rid, out var row);
 				Debug.Assert(b);
 				var url = nameReader.ReadDocumentName(row.Name);
 				var language = pdbMetadata.GuidStream.Read(row.Language) ?? Guid.Empty;
@@ -70,12 +71,13 @@ namespace dnlib.DotNet.Pdb.Portable {
 				var checkSumAlgorithmId = pdbMetadata.GuidStream.Read(row.HashAlgorithm) ?? Guid.Empty;
 				var checkSum = pdbMetadata.BlobStream.ReadNoNull(row.Hash);
 
-				var token = new MDToken(Table.Document, i + 1).ToInt32();
+				var mdToken = new MDToken(Table.Document, rid);
+				var token = mdToken.ToInt32();
 				custInfos.Clear();
 				GetCustomDebugInfos(token, gpContext, custInfos);
 				var custInfosArray = custInfos.Count == 0 ? Array2.Empty<PdbCustomDebugInfo>() : custInfos.ToArray();
 
-				docs[i] = new SymbolDocumentImpl(url, language, languageVendor, documentType, checkSumAlgorithmId, checkSum, custInfosArray);
+				docs[i] = new SymbolDocumentImpl(url, language, languageVendor, documentType, checkSumAlgorithmId, checkSum, custInfosArray, mdToken);
 			}
 			ListCache<PdbCustomDebugInfo>.Free(ref custInfos);
 			return docs;

--- a/src/DotNet/Pdb/Portable/SymbolDocumentImpl.cs
+++ b/src/DotNet/Pdb/Portable/SymbolDocumentImpl.cs
@@ -15,6 +15,7 @@ namespace dnlib.DotNet.Pdb.Portable {
 		/*readonly*/ Guid checkSumAlgorithmId;
 		readonly byte[] checkSum;
 		readonly PdbCustomDebugInfo[] customDebugInfos;
+		MDToken mdToken;
 
 		string GetDebuggerString() {
 			var sb = new StringBuilder();
@@ -45,8 +46,9 @@ namespace dnlib.DotNet.Pdb.Portable {
 		public override Guid CheckSumAlgorithmId => checkSumAlgorithmId;
 		public override byte[] CheckSum => checkSum;
 		public override PdbCustomDebugInfo[] CustomDebugInfos => customDebugInfos;
+		public override MDToken? MDToken => mdToken;
 
-		public SymbolDocumentImpl(string url, Guid language, Guid languageVendor, Guid documentType, Guid checkSumAlgorithmId, byte[] checkSum, PdbCustomDebugInfo[] customDebugInfos) {
+		public SymbolDocumentImpl(string url, Guid language, Guid languageVendor, Guid documentType, Guid checkSumAlgorithmId, byte[] checkSum, PdbCustomDebugInfo[] customDebugInfos, MDToken mdToken) {
 			this.url = url;
 			this.language = language;
 			this.languageVendor = languageVendor;
@@ -54,6 +56,7 @@ namespace dnlib.DotNet.Pdb.Portable {
 			this.checkSumAlgorithmId = checkSumAlgorithmId;
 			this.checkSum = checkSum;
 			this.customDebugInfos = customDebugInfos;
+			this.mdToken = mdToken;
 		}
 	}
 }

--- a/src/DotNet/Pdb/Symbols/SymbolDocument.cs
+++ b/src/DotNet/Pdb/Symbols/SymbolDocument.cs
@@ -41,5 +41,10 @@ namespace dnlib.DotNet.Pdb.Symbols {
 		/// Gets the custom debug infos
 		/// </summary>
 		public abstract PdbCustomDebugInfo[] CustomDebugInfos { get; }
+
+		/// <summary>
+		/// Gets the Metadata token of the document if available.
+		/// </summary>
+		public abstract MDToken? MDToken { get; }
 	}
 }

--- a/src/DotNet/Writer/Metadata.cs
+++ b/src/DotNet/Writer/Metadata.cs
@@ -3384,6 +3384,8 @@ namespace dnlib.DotNet.Writer {
 			case PdbCustomDebugInfoKind.SourceLink:
 			case PdbCustomDebugInfoKind.CompilationMetadataReferences:
 			case PdbCustomDebugInfoKind.CompilationOptions:
+			case PdbCustomDebugInfoKind.TypeDefinitionDocuments:
+			case PdbCustomDebugInfoKind.EditAndContinueStateMachineStateMap:
 				AddCustomDebugInformationCore(serializerMethodContext, encodedToken, cdi, cdi.Guid);
 				break;
 


### PR DESCRIPTION
Add support for the following CustomDebugInfos:
* TypeDefinitionDocuments  (fixes #430)
* EncStateMachineStateMap 