### PR TITLE
Add rudimentary support for `DeserializingResourceReader`

### DIFF
--- a/src/DotNet/Resources/BuiltInResourceData.cs
+++ b/src/DotNet/Resources/BuiltInResourceData.cs
@@ -113,6 +113,8 @@ namespace dnlib.DotNet.Resources {
 
 			case ResourceTypeCode.ByteArray:
 			case ResourceTypeCode.Stream:
+				if (writer.FormatVersion == 1)
+					throw new NotSupportedException();
 				var ary = (byte[])data;
 				writer.Write(ary.Length);
 				writer.Write(ary);

--- a/src/DotNet/Resources/BuiltInResourceData.cs
+++ b/src/DotNet/Resources/BuiltInResourceData.cs
@@ -114,7 +114,7 @@ namespace dnlib.DotNet.Resources {
 			case ResourceTypeCode.ByteArray:
 			case ResourceTypeCode.Stream:
 				if (writer.FormatVersion == 1)
-					throw new NotSupportedException();
+					throw new NotSupportedException($"{code} is not supported in format version 1 resources");
 				var ary = (byte[])data;
 				writer.Write(ary.Length);
 				writer.Write(ary);

--- a/src/DotNet/Resources/BuiltInResourceData.cs
+++ b/src/DotNet/Resources/BuiltInResourceData.cs
@@ -21,10 +21,10 @@ namespace dnlib.DotNet.Resources {
 		/// <inheritdoc/>
 		public ResourceTypeCode Code => code;
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="IResourceData.StartOffset" />
 		public FileOffset StartOffset { get; set; }
 
-		/// <inheritdoc/>
+		/// <inheritdoc cref="IResourceData.EndOffset" />
 		public FileOffset EndOffset { get; set; }
 
 		/// <summary>
@@ -38,7 +38,7 @@ namespace dnlib.DotNet.Resources {
 		}
 
 		/// <inheritdoc/>
-		public void WriteData(BinaryWriter writer, IFormatter formatter) {
+		public void WriteData(ResourceBinaryWriter writer, IFormatter formatter) {
 			switch (code) {
 			case ResourceTypeCode.Null:
 				break;
@@ -100,7 +100,11 @@ namespace dnlib.DotNet.Resources {
 				break;
 
 			case ResourceTypeCode.DateTime:
-				writer.Write(((DateTime)data).ToBinary());
+				var dateTime = (DateTime)data;
+				if (writer.FormatVersion == 1)
+					writer.Write(dateTime.Ticks);
+				else
+					writer.Write(dateTime.ToBinary());
 				break;
 
 			case ResourceTypeCode.TimeSpan:

--- a/src/DotNet/Resources/IResourceData.cs
+++ b/src/DotNet/Resources/IResourceData.cs
@@ -30,6 +30,6 @@ namespace dnlib.DotNet.Resources {
 		/// </summary>
 		/// <param name="writer">Writer</param>
 		/// <param name="formatter">Formatter if needed by implementer</param>
-		void WriteData(BinaryWriter writer, IFormatter formatter);
+		void WriteData(ResourceBinaryWriter writer, IFormatter formatter);
 	}
 }

--- a/src/DotNet/Resources/ResourceBinaryWriter.cs
+++ b/src/DotNet/Resources/ResourceBinaryWriter.cs
@@ -1,0 +1,27 @@
+using System.IO;
+
+namespace dnlib.DotNet.Resources {
+	/// <summary>
+	/// Extension of <see cref="BinaryWriter"/> for writing resource set elements
+	/// </summary>
+	public sealed class ResourceBinaryWriter : BinaryWriter {
+		/// <summary>
+		/// Format version of the resource set
+		/// </summary>
+		public int FormatVersion { get; internal set; }
+
+		/// <summary>
+		/// Specifies the target reader type of the resource set
+		/// </summary>
+		public ResourceReaderType ReaderType { get; internal set; }
+
+		/// <inheritdoc />
+		public ResourceBinaryWriter(Stream stream) : base(stream) { }
+
+		/// <summary>
+		/// Writes a 7-bit encoded integer.
+		/// </summary>
+		/// <param name="value">The value to write</param>
+		public new void Write7BitEncodedInt(int value) => base.Write7BitEncodedInt(value);
+	}
+}

--- a/src/DotNet/Resources/ResourceBinaryWriter.cs
+++ b/src/DotNet/Resources/ResourceBinaryWriter.cs
@@ -15,8 +15,7 @@ namespace dnlib.DotNet.Resources {
 		/// </summary>
 		public ResourceReaderType ReaderType { get; internal set; }
 
-		/// <inheritdoc />
-		public ResourceBinaryWriter(Stream stream) : base(stream) { }
+		internal ResourceBinaryWriter(Stream stream) : base(stream) { }
 
 		/// <summary>
 		/// Writes a 7-bit encoded integer.

--- a/src/DotNet/Resources/ResourceDataFactory.cs
+++ b/src/DotNet/Resources/ResourceDataFactory.cs
@@ -173,18 +173,18 @@ namespace dnlib.DotNet.Resources {
 		/// <param name="value">Serialized data</param>
 		/// <param name="type">Type of serialized data</param>
 		/// <returns></returns>
-		public BinaryResourceData CreateSerialized(byte[] value, UserResourceType type) => new BinaryResourceData(CreateUserResourceType(type.Name, true), value);
+		public BinaryResourceData CreateSerialized(byte[] value, SerializationFormat format, UserResourceType type) => new BinaryResourceData(CreateUserResourceType(type.Name, true), value, format);
 
 		/// <summary>
 		/// Creates serialized data
 		/// </summary>
 		/// <param name="value">Serialized data</param>
 		/// <returns></returns>
-		public BinaryResourceData CreateSerialized(byte[] value) {
+		public BinaryResourceData CreateBinaryFormatterSerialized(byte[] value) {
 			if (!GetSerializedTypeAndAssemblyName(value, out var assemblyName, out var typeName))
 				throw new ApplicationException("Could not get serialized type name");
 			string fullName = $"{typeName}, {assemblyName}";
-			return new BinaryResourceData(CreateUserResourceType(fullName), value);
+			return new BinaryResourceData(CreateUserResourceType(fullName), value, SerializationFormat.BinaryFormatter);
 		}
 
 		sealed class MyBinder : SerializationBinder {

--- a/src/DotNet/Resources/ResourceDataFactory.cs
+++ b/src/DotNet/Resources/ResourceDataFactory.cs
@@ -171,6 +171,7 @@ namespace dnlib.DotNet.Resources {
 		/// Creates serialized data
 		/// </summary>
 		/// <param name="value">Serialized data</param>
+		/// <param name="format">Format of the serialized data</param>
 		/// <param name="type">Type of serialized data</param>
 		/// <returns></returns>
 		public BinaryResourceData CreateSerialized(byte[] value, SerializationFormat format, UserResourceType type) => new BinaryResourceData(CreateUserResourceType(type.Name, true), value, format);

--- a/src/DotNet/Resources/ResourceDataFactory.cs
+++ b/src/DotNet/Resources/ResourceDataFactory.cs
@@ -221,6 +221,38 @@ namespace dnlib.DotNet.Resources {
 		}
 
 		/// <summary>
+		///	Creates a user type for a built-in resource type code.
+		/// Useful when writing V1 resources.
+		/// </summary>
+		/// <param name="typeCode">The built-in resource type code or null if not supported</param>
+		/// <returns></returns>
+		public UserResourceType CreateBuiltinResourceType(ResourceTypeCode typeCode) {
+			string typeName = typeCode switch {
+				ResourceTypeCode.String => "System.String",
+				ResourceTypeCode.Boolean => "System.Boolean",
+				ResourceTypeCode.Char => "System.Char",
+				ResourceTypeCode.Byte => "System.Byte",
+				ResourceTypeCode.SByte => "System.SByte",
+				ResourceTypeCode.Int16 => "System.Int16",
+				ResourceTypeCode.UInt16 => "System.UInt16",
+				ResourceTypeCode.Int32 => "System.Int32",
+				ResourceTypeCode.UInt32 => "System.UInt32",
+				ResourceTypeCode.Int64 => "System.Int64",
+				ResourceTypeCode.UInt64 => "System.UInt64",
+				ResourceTypeCode.Single => "System.Single",
+				ResourceTypeCode.Double => "System.Double",
+				ResourceTypeCode.Decimal => "System.Decimal",
+				ResourceTypeCode.DateTime => "System.DateTime",
+				ResourceTypeCode.TimeSpan => "System.TimeSpan",
+				_ => null
+			};
+			if (typeName is null)
+				return null;
+
+			return CreateUserResourceType($"{typeName}, {module.CorLibTypes.AssemblyRef.FullName}", true);
+		}
+
+		/// <summary>
 		/// Creates a user type. If the type already exists, the existing value is returned.
 		/// </summary>
 		/// <param name="fullName">Full name of type</param>

--- a/src/DotNet/Resources/ResourceElementSet.cs
+++ b/src/DotNet/Resources/ResourceElementSet.cs
@@ -103,5 +103,13 @@ namespace dnlib.DotNet.Resources {
 				FormatVersion = formatVersion
 			};
 		}
+
+		/// <summary>
+		/// Creates a new <see cref="ResourceElementSet"/> instance based on this instance
+		/// </summary>
+		/// <returns></returns>
+		public ResourceElementSet Clone() => new ResourceElementSet(ResourceReaderTypeName, ResourceSetTypeName, ReaderType) {
+			FormatVersion = FormatVersion
+		};
 	}
 }

--- a/src/DotNet/Resources/ResourceElementSet.cs
+++ b/src/DotNet/Resources/ResourceElementSet.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace dnlib.DotNet.Resources {
 	/// <summary>
@@ -9,6 +10,37 @@ namespace dnlib.DotNet.Resources {
 	/// </summary>
 	public sealed class ResourceElementSet {
 		readonly Dictionary<string, ResourceElement> dict = new Dictionary<string, ResourceElement>(StringComparer.Ordinal);
+
+		/// <summary>
+		/// The ResourceReader type name used by this set
+		/// </summary>
+		public string ResourceReaderTypeName { get; internal set; }
+
+		/// <summary>
+		/// Gets whether <see cref="ResourceReaderTypeName"/> is a DeserializingResourceReader
+		/// </summary>
+		public bool UsesDeserializingResourceReader => ResourceReaderTypeName is not null && Regex.IsMatch(ResourceReaderTypeName, @"^System\.Resources\.Extensions\.DeserializingResourceReader,\s*System\.Resources\.Extensions");
+
+		/// <summary>
+		/// The ResourceSet type name used by this set
+		/// </summary>
+		public string ResourceSetTypeName { get; internal set; }
+
+		/// <summary>
+		///	Constructor for backwards compatibility only. Use Create methods instead.
+		/// </summary>
+		public ResourceElementSet() : this(null, null) {
+		}
+
+		/// <summary>
+		///	Creates a new <see cref="ResourceElementSet"/> instance
+		/// </summary>
+		/// <param name="resourceReaderTypeName">The ResourceReader type name to use</param>
+		/// <param name="resourceSetTypeName">The ResourceSet type name to use</param>
+		public ResourceElementSet(string resourceReaderTypeName, string resourceSetTypeName) {
+			ResourceReaderTypeName = resourceReaderTypeName;
+			ResourceSetTypeName = resourceSetTypeName;
+		}
 
 		/// <summary>
 		/// Gets the number of elements in the set
@@ -25,5 +57,38 @@ namespace dnlib.DotNet.Resources {
 		/// </summary>
 		/// <param name="elem"></param>
 		public void Add(ResourceElement elem) => dict[elem.Name] = elem;
+
+		/// <summary>
+		/// Creates a new <see cref="ResourceElementSet"/> instance for a DeserializingResourceReader
+		/// </summary>
+		/// <param name="extensionAssemblyVersion"></param>
+		public static ResourceElementSet CreateForDeserializingResourceReader(Version extensionAssemblyVersion) {
+			var extensionAssemblyFullName = $"System.Resources.Extensions, Version={extensionAssemblyVersion.ToString(4)}, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51";
+			return new ResourceElementSet($"System.Resources.Extensions.DeserializingResourceReader, {extensionAssemblyFullName}", $"System.Resources.Extensions.RuntimeResourceSet, {extensionAssemblyFullName}");
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="ResourceElementSet"/> instance for a ResourceReader
+		/// </summary>
+		/// <param name="module">Module in which the set will reside</param>
+		public static ResourceElementSet CreateForResourceReader(ModuleDef module) {
+			string mscorlibFullName;
+			if (module.CorLibTypes.AssemblyRef.Name == "mscorlib") {
+				// Use mscorlib reference found in module.
+				mscorlibFullName = module.CorLibTypes.AssemblyRef.FullName;
+			}
+			else {
+				// Use a reference to 4.0.0.0 mscorlib for compatibility with .NET Core and .NET 5 and later.
+				mscorlibFullName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+			}
+			return new ResourceElementSet($"System.Resources.ResourceReader, {mscorlibFullName}", "System.Resources.RuntimeResourceSet");
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="ResourceElementSet"/> instance for a ResourceReader
+		/// </summary>
+		/// <param name="mscorlibVersion">mscorlib assembly version</param>
+		public static ResourceElementSet CreateForResourceReader(Version mscorlibVersion) =>
+			new ResourceElementSet($"System.Resources.ResourceReader, mscorlib, Version={mscorlibVersion.ToString(4)}, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Resources.RuntimeResourceSet");
 	}
 }

--- a/src/DotNet/Resources/ResourceElementSet.cs
+++ b/src/DotNet/Resources/ResourceElementSet.cs
@@ -43,7 +43,6 @@ namespace dnlib.DotNet.Resources {
 			ResourceReaderTypeName = resourceReaderTypeName;
 			ResourceSetTypeName = resourceSetTypeName;
 			ReaderType = readerType;
-			FormatVersion = 2;
 		}
 
 		/// <summary>
@@ -65,17 +64,21 @@ namespace dnlib.DotNet.Resources {
 		/// <summary>
 		/// Creates a new <see cref="ResourceElementSet"/> instance for a DeserializingResourceReader
 		/// </summary>
-		/// <param name="extensionAssemblyVersion"></param>
-		public static ResourceElementSet CreateForDeserializingResourceReader(Version extensionAssemblyVersion) {
+		/// <param name="extensionAssemblyVersion">Version of System.Resources.Extensions assembly to use</param>
+		/// <param name="formatVersion">Resource format version, the default is 2</param>
+		public static ResourceElementSet CreateForDeserializingResourceReader(Version extensionAssemblyVersion, int formatVersion = 2) {
 			var extensionAssemblyFullName = $"System.Resources.Extensions, Version={extensionAssemblyVersion.ToString(4)}, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51";
-			return new ResourceElementSet($"System.Resources.Extensions.DeserializingResourceReader, {extensionAssemblyFullName}", $"System.Resources.Extensions.RuntimeResourceSet, {extensionAssemblyFullName}", ResourceReaderType.DeserializingResourceReader);
+			return new ResourceElementSet($"System.Resources.Extensions.DeserializingResourceReader, {extensionAssemblyFullName}", $"System.Resources.Extensions.RuntimeResourceSet, {extensionAssemblyFullName}", ResourceReaderType.DeserializingResourceReader) {
+				FormatVersion = formatVersion
+			};
 		}
 
 		/// <summary>
 		/// Creates a new <see cref="ResourceElementSet"/> instance for a ResourceReader
 		/// </summary>
 		/// <param name="module">Module in which the set will reside</param>
-		public static ResourceElementSet CreateForResourceReader(ModuleDef module) {
+		/// /// <param name="formatVersion">Resource format version, the default is 2</param>
+		public static ResourceElementSet CreateForResourceReader(ModuleDef module, int formatVersion = 2) {
 			string mscorlibFullName;
 			if (module.CorLibTypes.AssemblyRef.Name == "mscorlib") {
 				// Use mscorlib reference found in module.
@@ -85,14 +88,20 @@ namespace dnlib.DotNet.Resources {
 				// Use a reference to 4.0.0.0 mscorlib for compatibility with .NET Core, .NET 5, and later.
 				mscorlibFullName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
 			}
-			return new ResourceElementSet($"System.Resources.ResourceReader, {mscorlibFullName}", "System.Resources.RuntimeResourceSet", ResourceReaderType.ResourceReader);
+			return new ResourceElementSet($"System.Resources.ResourceReader, {mscorlibFullName}", "System.Resources.RuntimeResourceSet", ResourceReaderType.ResourceReader) {
+				FormatVersion = formatVersion
+			};
 		}
 
 		/// <summary>
 		/// Creates a new <see cref="ResourceElementSet"/> instance for a ResourceReader
 		/// </summary>
 		/// <param name="mscorlibVersion">mscorlib assembly version</param>
-		public static ResourceElementSet CreateForResourceReader(Version mscorlibVersion) =>
-			new ResourceElementSet($"System.Resources.ResourceReader, mscorlib, Version={mscorlibVersion.ToString(4)}, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Resources.RuntimeResourceSet", ResourceReaderType.ResourceReader);
+		/// <param name="formatVersion">Resource format version, the default is 2</param>
+		public static ResourceElementSet CreateForResourceReader(Version mscorlibVersion, int formatVersion = 2) {
+			return new ResourceElementSet($"System.Resources.ResourceReader, mscorlib, Version={mscorlibVersion.ToString(4)}, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Resources.RuntimeResourceSet", ResourceReaderType.ResourceReader) {
+				FormatVersion = formatVersion
+			};
+		}
 	}
 }

--- a/src/DotNet/Resources/ResourceElementSet.cs
+++ b/src/DotNet/Resources/ResourceElementSet.cs
@@ -2,44 +2,47 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace dnlib.DotNet.Resources {
 	/// <summary>
 	/// Resource element set
 	/// </summary>
 	public sealed class ResourceElementSet {
+		internal const string DeserializingResourceReaderTypeNameRegex = @"^System\.Resources\.Extensions\.DeserializingResourceReader,\s*System\.Resources\.Extensions";
+		internal const string ResourceReaderTypeNameRegex = @"^System\.Resources\.ResourceReader,\s*mscorlib";
+
 		readonly Dictionary<string, ResourceElement> dict = new Dictionary<string, ResourceElement>(StringComparer.Ordinal);
 
 		/// <summary>
 		/// The ResourceReader type name used by this set
 		/// </summary>
-		public string ResourceReaderTypeName { get; internal set; }
-
-		/// <summary>
-		/// Gets whether <see cref="ResourceReaderTypeName"/> is a DeserializingResourceReader
-		/// </summary>
-		public bool UsesDeserializingResourceReader => ResourceReaderTypeName is not null && Regex.IsMatch(ResourceReaderTypeName, @"^System\.Resources\.Extensions\.DeserializingResourceReader,\s*System\.Resources\.Extensions");
+		public string ResourceReaderTypeName { get; }
 
 		/// <summary>
 		/// The ResourceSet type name used by this set
 		/// </summary>
-		public string ResourceSetTypeName { get; internal set; }
+		public string ResourceSetTypeName { get; }
 
 		/// <summary>
-		///	Constructor for backwards compatibility only. Use Create methods instead.
+		/// The type of resource reader used to read this set
 		/// </summary>
-		public ResourceElementSet() : this(null, null) {
-		}
+		public ResourceReaderType ReaderType { get; }
+
+		/// <summary>
+		/// Format version of the resource set
+		/// </summary>
+		public int FormatVersion { get; internal set; }
 
 		/// <summary>
 		///	Creates a new <see cref="ResourceElementSet"/> instance
 		/// </summary>
 		/// <param name="resourceReaderTypeName">The ResourceReader type name to use</param>
 		/// <param name="resourceSetTypeName">The ResourceSet type name to use</param>
-		public ResourceElementSet(string resourceReaderTypeName, string resourceSetTypeName) {
+		/// <param name="readerType"></param>
+		internal ResourceElementSet(string resourceReaderTypeName, string resourceSetTypeName, ResourceReaderType readerType) {
 			ResourceReaderTypeName = resourceReaderTypeName;
 			ResourceSetTypeName = resourceSetTypeName;
+			ReaderType = readerType;
 		}
 
 		/// <summary>
@@ -64,7 +67,7 @@ namespace dnlib.DotNet.Resources {
 		/// <param name="extensionAssemblyVersion"></param>
 		public static ResourceElementSet CreateForDeserializingResourceReader(Version extensionAssemblyVersion) {
 			var extensionAssemblyFullName = $"System.Resources.Extensions, Version={extensionAssemblyVersion.ToString(4)}, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51";
-			return new ResourceElementSet($"System.Resources.Extensions.DeserializingResourceReader, {extensionAssemblyFullName}", $"System.Resources.Extensions.RuntimeResourceSet, {extensionAssemblyFullName}");
+			return new ResourceElementSet($"System.Resources.Extensions.DeserializingResourceReader, {extensionAssemblyFullName}", $"System.Resources.Extensions.RuntimeResourceSet, {extensionAssemblyFullName}", ResourceReaderType.DeserializingResourceReader);
 		}
 
 		/// <summary>
@@ -78,10 +81,10 @@ namespace dnlib.DotNet.Resources {
 				mscorlibFullName = module.CorLibTypes.AssemblyRef.FullName;
 			}
 			else {
-				// Use a reference to 4.0.0.0 mscorlib for compatibility with .NET Core and .NET 5 and later.
+				// Use a reference to 4.0.0.0 mscorlib for compatibility with .NET Core, .NET 5, and later.
 				mscorlibFullName = "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
 			}
-			return new ResourceElementSet($"System.Resources.ResourceReader, {mscorlibFullName}", "System.Resources.RuntimeResourceSet");
+			return new ResourceElementSet($"System.Resources.ResourceReader, {mscorlibFullName}", "System.Resources.RuntimeResourceSet", ResourceReaderType.ResourceReader);
 		}
 
 		/// <summary>
@@ -89,6 +92,6 @@ namespace dnlib.DotNet.Resources {
 		/// </summary>
 		/// <param name="mscorlibVersion">mscorlib assembly version</param>
 		public static ResourceElementSet CreateForResourceReader(Version mscorlibVersion) =>
-			new ResourceElementSet($"System.Resources.ResourceReader, mscorlib, Version={mscorlibVersion.ToString(4)}, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Resources.RuntimeResourceSet");
+			new ResourceElementSet($"System.Resources.ResourceReader, mscorlib, Version={mscorlibVersion.ToString(4)}, Culture=neutral, PublicKeyToken=b77a5c561934e089", "System.Resources.RuntimeResourceSet", ResourceReaderType.ResourceReader);
 	}
 }

--- a/src/DotNet/Resources/ResourceElementSet.cs
+++ b/src/DotNet/Resources/ResourceElementSet.cs
@@ -43,6 +43,7 @@ namespace dnlib.DotNet.Resources {
 			ResourceReaderTypeName = resourceReaderTypeName;
 			ResourceSetTypeName = resourceSetTypeName;
 			ReaderType = readerType;
+			FormatVersion = 2;
 		}
 
 		/// <summary>

--- a/src/DotNet/Resources/ResourceReader.cs
+++ b/src/DotNet/Resources/ResourceReader.cs
@@ -45,6 +45,7 @@ namespace dnlib.DotNet.Resources {
 	/// <param name="resourceDataFactory">ResourceDataFactory</param>
 	/// <param name="type">Serialized type</param>
 	/// <param name="serializedData">Serialized data</param>
+	/// <param name="format">Format of the serialized data</param>
 	/// <returns></returns>
 	public delegate IResourceData CreateResourceDataDelegate(ResourceDataFactory resourceDataFactory, UserResourceType type, byte[] serializedData, SerializationFormat format);
 
@@ -234,6 +235,8 @@ namespace dnlib.DotNet.Resources {
 				return res ?? resourceDataFactory.CreateSerialized(serializedData, SerializationFormat.BinaryFormatter, type);
 			case ResourceReaderType.DeserializingResourceReader: {
 				var format = (SerializationFormat)reader.Read7BitEncodedInt32();
+				if (format < SerializationFormat.BinaryFormatter || format > SerializationFormat.ActivatorStream)
+					throw new ResourceReaderException($"Invalid serialization format: {format}");
 				int length = reader.Read7BitEncodedInt32();
 				Debug.Assert(length == (int)(endPos - reader.Position));
 				serializedData = reader.ReadBytes(length);

--- a/src/DotNet/Resources/ResourceReader.cs
+++ b/src/DotNet/Resources/ResourceReader.cs
@@ -58,9 +58,9 @@ namespace dnlib.DotNet.Resources {
 		readonly ResourceDataFactory resourceDataFactory;
 		readonly CreateResourceDataDelegate createResourceDataDelegate;
 
-		ResourceReader(ModuleDef module, ref DataReader reader, CreateResourceDataDelegate createResourceDataDelegate) {
+		ResourceReader(ResourceDataFactory resourceDataFactory, ref DataReader reader, CreateResourceDataDelegate createResourceDataDelegate) {
 			this.reader = reader;
-			resourceDataFactory = new ResourceDataFactory(module);
+			this.resourceDataFactory = resourceDataFactory;
 			this.createResourceDataDelegate = createResourceDataDelegate;
 			baseFileOffset = reader.StartOffset;
 		}
@@ -89,7 +89,17 @@ namespace dnlib.DotNet.Resources {
 		/// <param name="createResourceDataDelegate">Call back that gets called to create a <see cref="IResourceData"/> instance. Can be null.</param>
 		/// <returns></returns>
 		public static ResourceElementSet Read(ModuleDef module, DataReader reader, CreateResourceDataDelegate createResourceDataDelegate) =>
-			new ResourceReader(module, ref reader, createResourceDataDelegate).Read();
+			Read(new ResourceDataFactory(module), reader, createResourceDataDelegate);
+
+		/// <summary>
+		/// Reads a .NET resource
+		/// </summary>
+		/// <param name="resourceDataFactory">User type resource data factory</param>
+		/// <param name="reader">Data of resource</param>
+		/// <param name="createResourceDataDelegate">Call back that gets called to create a <see cref="IResourceData"/> instance. Can be null.</param>
+		/// <returns></returns>
+		public static ResourceElementSet Read(ResourceDataFactory resourceDataFactory, DataReader reader, CreateResourceDataDelegate createResourceDataDelegate) =>
+			new ResourceReader(resourceDataFactory, ref reader, createResourceDataDelegate).Read();
 
 		ResourceElementSet Read() {
 			uint sig = reader.ReadUInt32();

--- a/src/DotNet/Resources/ResourceReaderType.cs
+++ b/src/DotNet/Resources/ResourceReaderType.cs
@@ -1,0 +1,15 @@
+namespace dnlib.DotNet.Resources {
+	/// <summary>
+	/// Resource reader type
+	/// </summary>
+	public enum ResourceReaderType {
+		/// <summary>
+		/// System.Resources.ResourceReader
+		/// </summary>
+		ResourceReader,
+		/// <summary>
+		/// System.Resources.Extensions.DeserializingResourceReader
+		/// </summary>
+		DeserializingResourceReader,
+	}
+}

--- a/src/DotNet/Resources/ResourceWriter.cs
+++ b/src/DotNet/Resources/ResourceWriter.cs
@@ -120,9 +120,15 @@ namespace dnlib.DotNet.Resources {
 		void WriteReaderType() {
 			var memStream = new MemoryStream();
 			var headerWriter = new BinaryWriter(memStream);
-			var mscorlibFullName = GetMscorlibFullname();
-			headerWriter.Write("System.Resources.ResourceReader, " + mscorlibFullName);
-			headerWriter.Write("System.Resources.RuntimeResourceSet");
+			if (resources.ResourceReaderTypeName is not null && resources.ResourceSetTypeName is not null) {
+				headerWriter.Write(resources.ResourceReaderTypeName);
+				headerWriter.Write(resources.ResourceSetTypeName);
+			}
+			else {
+				var mscorlibFullName = GetMscorlibFullname();
+				headerWriter.Write("System.Resources.ResourceReader, " + mscorlibFullName);
+				headerWriter.Write("System.Resources.RuntimeResourceSet");
+			}
 			writer.Write((int)memStream.Position);
 			writer.Write(memStream.ToArray());
 		}

--- a/src/DotNet/Resources/ResourceWriter.cs
+++ b/src/DotNet/Resources/ResourceWriter.cs
@@ -18,9 +18,9 @@ namespace dnlib.DotNet.Resources {
 		ResourceDataFactory typeCreator;
 		Dictionary<UserResourceData, UserResourceType> dataToNewType = new Dictionary<UserResourceData, UserResourceType>();
 
-		ResourceWriter(ModuleDef module, Stream stream, ResourceElementSet resources) {
+		ResourceWriter(ModuleDef module, ResourceDataFactory typeCreator, Stream stream, ResourceElementSet resources) {
 			this.module = module;
-			typeCreator = new ResourceDataFactory(module);
+			this.typeCreator = typeCreator;
 			writer = new BinaryWriter(stream);
 			this.resources = resources;
 		}
@@ -32,7 +32,17 @@ namespace dnlib.DotNet.Resources {
 		/// <param name="stream">Output stream</param>
 		/// <param name="resources">.NET resources</param>
 		public static void Write(ModuleDef module, Stream stream, ResourceElementSet resources) =>
-			new ResourceWriter(module, stream, resources).Write();
+			new ResourceWriter(module, new ResourceDataFactory(module), stream, resources).Write();
+
+		/// <summary>
+		/// Write .NET resources
+		/// </summary>
+		/// <param name="module">Owner module</param>
+		/// <param name="typeCreator">User type factory</param>
+		/// <param name="stream">Output stream</param>
+		/// <param name="resources">.NET resources</param>
+		public static void Write(ModuleDef module, ResourceDataFactory typeCreator, Stream stream, ResourceElementSet resources) =>
+			new ResourceWriter(module, typeCreator, stream, resources).Write();
 
 		void Write() {
 			InitializeUserTypes();

--- a/src/DotNet/Resources/ResourceWriter.cs
+++ b/src/DotNet/Resources/ResourceWriter.cs
@@ -45,6 +45,9 @@ namespace dnlib.DotNet.Resources {
 			new ResourceWriter(module, typeCreator, stream, resources).Write();
 
 		void Write() {
+			if (resources.FormatVersion != 1 && resources.FormatVersion != 2)
+				throw new ArgumentException("Invalid format version: " + resources.FormatVersion, nameof(resources));
+
 			InitializeUserTypes(resources.FormatVersion);
 
 			writer.Write(0xBEEFCACE);

--- a/src/DotNet/Resources/UserResourceData.cs
+++ b/src/DotNet/Resources/UserResourceData.cs
@@ -1,5 +1,6 @@
 // dnlib: See LICENSE.txt for more info
 
+using System;
 using System.IO;
 using System.Runtime.Serialization;
 using dnlib.IO;
@@ -68,6 +69,9 @@ namespace dnlib.DotNet.Resources {
 
 		/// <inheritdoc/>
 		public override void WriteData(ResourceBinaryWriter writer, IFormatter formatter) {
+			if (writer.ReaderType == ResourceReaderType.ResourceReader && format != SerializationFormat.BinaryFormatter)
+				throw new NotSupportedException();
+
 			if (writer.ReaderType == ResourceReaderType.DeserializingResourceReader) {
 				writer.Write7BitEncodedInt((int)format);
 				writer.Write7BitEncodedInt(data.Length);

--- a/src/DotNet/Resources/UserResourceData.cs
+++ b/src/DotNet/Resources/UserResourceData.cs
@@ -70,7 +70,7 @@ namespace dnlib.DotNet.Resources {
 		/// <inheritdoc/>
 		public override void WriteData(ResourceBinaryWriter writer, IFormatter formatter) {
 			if (writer.ReaderType == ResourceReaderType.ResourceReader && format != SerializationFormat.BinaryFormatter)
-				throw new NotSupportedException();
+				throw new NotSupportedException($"Unsupported serialization format: {format} for {writer.ReaderType}");
 
 			if (writer.ReaderType == ResourceReaderType.DeserializingResourceReader) {
 				writer.Write7BitEncodedInt((int)format);


### PR DESCRIPTION
* Updated code in `CheckReaders` to match the actual meaning of the fields. The implementation now matches the one in the runtime.
* Added several new members to allow creating of more customized resource sets.
* Added support for the `DeserializingResourceReader` class introduced in .NET 5 and now in the `System.Resources.Extensions` package.

The changes should be source and binary compatible with the previous dnlib version. This limited the support I could provide for this new resource reader which specifies additional information on how to deserialize objects with different serialization kinds for the `UserType` type code.

See:
https://github.com/dotnet/dotnet/blob/95703b57cf3dfaa79f054d277551a809d4f7696a/src/runtime/src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/DeserializingResourceReader.cs#L108

The old `ResourceReader` always used `BinaryFormater` while the new code will first read some additional information and then deserialize the object. This new implementation in dnlib leaves the handling of this to the user which could be confusing. Ideally, we'd want to handle that in dnlib itself but that can't be done without introducing breaking changes. 

Would it be OK for us to introduce breaking changes as part of a minor release or would this have to be part of a major release? I'd like to use this new code in [dnSpyEx](https://github.com/dnSpyEx) and would like to know if I should wait for the next minor release or perhaps, implement a custom version of the `ResourceReader` resource handling in dnSpyEx temporarily. If breaking changes are OK in this component, I'd also like to extend the writing support to support version 1 resources!