### PR TITLE
Add support for .NET 8.0 and `DynamicILInfo` to `DynamicMethodBodyReader`

### DIFF
--- a/src/DotNet/Emit/DynamicMethodBodyReader.cs
+++ b/src/DotNet/Emit/DynamicMethodBodyReader.cs
@@ -32,7 +32,7 @@ namespace dnlib.DotNet.Emit {
 	/// </summary>
 	public class DynamicMethodBodyReader : MethodBodyReaderBase, ISignatureReaderHelper {
 		static readonly ReflectionFieldInfo rtdmOwnerFieldInfo = new ReflectionFieldInfo("m_owner");
-		static readonly ReflectionFieldInfo dmResolverFieldInfo = new ReflectionFieldInfo("m_resolver");
+		static readonly ReflectionFieldInfo dmResolverFieldInfo = new ReflectionFieldInfo("m_resolver", "_resolver");
 		static readonly ReflectionFieldInfo rslvCodeFieldInfo = new ReflectionFieldInfo("m_code");
 		static readonly ReflectionFieldInfo rslvDynamicScopeFieldInfo = new ReflectionFieldInfo("m_scope");
 		static readonly ReflectionFieldInfo rslvMethodFieldInfo = new ReflectionFieldInfo("m_method");
@@ -99,7 +99,7 @@ namespace dnlib.DotNet.Emit {
 				if (fieldInfo is not null)
 					return;
 
-				var flags = SR.BindingFlags.Instance | SR.BindingFlags.Public | SR.BindingFlags.NonPublic;
+				const SR.BindingFlags flags = SR.BindingFlags.Instance | SR.BindingFlags.Public | SR.BindingFlags.NonPublic;
 				fieldInfo = type.GetField(fieldName1, flags);
 				if (fieldInfo is null && fieldName2 is not null)
 					fieldInfo = type.GetField(fieldName2, flags);

--- a/src/DotNet/Emit/MethodTableToTypeConverter.cs
+++ b/src/DotNet/Emit/MethodTableToTypeConverter.cs
@@ -34,6 +34,9 @@ namespace dnlib.DotNet.Emit {
 #endif
 				moduleBuilder = asmb.DefineDynamicModule("DynMod");
 			}
+
+			// In .NET 8+, ILGenerator is an abstract class and the actual ILGenerator implementation is found in RuntimeILGenerator.
+			localSignatureFieldInfo ??= Type.GetType("System.Reflection.Emit.RuntimeILGenerator")?.GetField("m_localSignature", BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 		}
 
 		/// <summary>


### PR DESCRIPTION
.NET 8 changed the following:
* `DynamicMethod.m_resolver` ->`DynamicMethod._resolver` - This field is used by `DynamicMethodBodyReader` to retrieve the `DynamicResolver` instance.
* `ILGnerator` became an abstract class and the actual implementation was moved to `RuntimeILGenerator` - `MethodTableToTypeConverter` accesses a private field in the ILGenerator implementation and needed to be updated to check `RuntimeILGenerator`

I've also added support for `DynamicMethodBodyReader` to consume dynamic methods created from a `DynamicILInfo` which were not jet used as part of an invocation or a delegate.