### PR TITLE
Expose `WinMDHelpers` class

### DIFF
--- a/src/DotNet/WinMDHelpers.cs
+++ b/src/DotNet/WinMDHelpers.cs
@@ -14,7 +14,10 @@ namespace dnlib.DotNet {
 		SystemRuntimeWindowsRuntimeUIXaml,
 	}
 
-	static class WinMDHelpers {
+	/// <summary>
+	/// Helper class to project WinMD types to CLR types
+	/// </summary>
+	public static class WinMDHelpers {
 		readonly struct ClassName : IEquatable<ClassName> {
 			public readonly UTF8String Namespace;
 			public readonly UTF8String Name;


### PR DESCRIPTION
The rationale for the `WinMDHelpers` change can be found in: https://github.com/0xd4d/dnlib/issues/510