### PR TITLE
Add additional net6.0 target framework

### DIFF
--- a/src/DotNet/AssemblyResolver.cs
+++ b/src/DotNet/AssemblyResolver.cs
@@ -763,10 +763,13 @@ namespace dnlib.DotNet {
 			try {
 				var imageName = module.Location;
 				if (imageName != string.Empty) {
-					baseDir = Directory.GetParent(imageName).FullName;
-					var configName = imageName + ".config";
-					if (File.Exists(configName))
-						return GetPrivatePaths(baseDir, configName);
+					var directoryInfo = Directory.GetParent(imageName);
+					if (directoryInfo is not null) {
+						baseDir = directoryInfo.FullName;
+						var configName = imageName + ".config";
+						if (File.Exists(configName))
+							return GetPrivatePaths(baseDir, configName);
+					}
 				}
 			}
 			catch {

--- a/src/DotNet/Emit/MethodTableToTypeConverter.cs
+++ b/src/DotNet/Emit/MethodTableToTypeConverter.cs
@@ -27,7 +27,7 @@ namespace dnlib.DotNet.Emit {
 
 		static MethodTableToTypeConverter() {
 			if (ptrFieldInfo is null) {
-#if NETSTANDARD
+#if NETSTANDARD || NETCOREAPP
 				var asmb = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("DynAsm"), AssemblyBuilderAccess.Run);
 #else
 				var asmb = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("DynAsm"), AssemblyBuilderAccess.Run);

--- a/src/DotNet/Emit/MethodTableToTypeConverter.cs
+++ b/src/DotNet/Emit/MethodTableToTypeConverter.cs
@@ -121,7 +121,7 @@ namespace dnlib.DotNet.Emit {
 			return Type.GetTypeFromHandle((RuntimeTypeHandle)th);
 		}
 
-		static string GetNextTypeName() => "Type" + numNewTypes++.ToString();
+		static string GetNextTypeName() => $"Type{numNewTypes++}";
 
 		static byte[] GetLocalSignature(IntPtr mtAddr) {
 			ulong mtValue = (ulong)mtAddr.ToInt64();

--- a/src/DotNet/ImplMap.cs
+++ b/src/DotNet/ImplMap.cs
@@ -234,7 +234,7 @@ namespace dnlib.DotNet {
 		}
 
 		static bool IsWindows() =>
-#if NETSTANDARD
+#if NETSTANDARD || NETCOREAPP
 			RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #else
 			Path.DirectorySeparatorChar == '\\' || Path.AltDirectorySeparatorChar == '\\';

--- a/src/DotNet/Importer.cs
+++ b/src/DotNet/Importer.cs
@@ -382,7 +382,7 @@ namespace dnlib.DotNet {
 				pkt = null;
 			if (TryToUseExistingAssemblyRefs && module.GetAssemblyRef(asmName.Name) is AssemblyRef asmRef)
 				return asmRef;
-			return module.UpdateRowId(new AssemblyRefUser(asmName.Name, asmName.Version, PublicKeyBase.CreatePublicKeyToken(pkt), asmName.CultureInfo.Name));
+			return module.UpdateRowId(new AssemblyRefUser(asmName.Name, asmName.Version, PublicKeyBase.CreatePublicKeyToken(pkt), asmName.CultureInfo?.Name ?? string.Empty));
 		}
 
 		/// <summary>

--- a/src/DotNet/ModuleDefMD.cs
+++ b/src/DotNet/ModuleDefMD.cs
@@ -1495,7 +1495,12 @@ namespace dnlib.DotNet {
 			return new EmbeddedResourceMD(this, mr, Array2.Empty<byte>());
 		}
 
-		[HandleProcessCorruptedStateExceptions, SecurityCritical]	// Req'd on .NET Framework 4.0
+		// Required attributes on .NET Framework 4.0
+		// HandleProcessCorruptedStateExceptions is obsolete on .NET Core and newer
+#if !NETCOREAPP
+		[HandleProcessCorruptedStateExceptions]
+#endif
+		[SecurityCritical]
 		bool TryCreateResourceStream(uint offset, out DataReaderFactory dataReaderFactory, out uint resourceOffset, out uint resourceLength) {
 			dataReaderFactory = null;
 			resourceOffset = 0;

--- a/src/DotNet/Pdb/Dss/SymbolReaderWriterFactory.cs
+++ b/src/DotNet/Pdb/Dss/SymbolReaderWriterFactory.cs
@@ -6,11 +6,15 @@ using System.Runtime.InteropServices;
 using dnlib.IO;
 using dnlib.DotNet.Pdb.Symbols;
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using dnlib.PE;
 using dnlib.DotNet.Writer;
 using dnlib.DotNet.Pdb.WindowsPdb;
 
 namespace dnlib.DotNet.Pdb.Dss {
+#if NETCOREAPP
+	[SupportedOSPlatform("windows")]
+#endif
 	static class SymbolReaderWriterFactory {
 		[DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories | DllImportSearchPath.AssemblyDirectory)]
 		[DllImport("Microsoft.DiaSymReader.Native.x86.dll", EntryPoint = "CreateSymReader")]

--- a/src/DotNet/Pdb/Dss/SymbolWriterImpl.cs
+++ b/src/DotNet/Pdb/Dss/SymbolWriterImpl.cs
@@ -5,10 +5,14 @@ using System.Diagnostics;
 using System.Diagnostics.SymbolStore;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using dnlib.DotNet.Pdb.WindowsPdb;
 using dnlib.DotNet.Writer;
 
 namespace dnlib.DotNet.Pdb.Dss {
+#if NETCOREAPP
+	[SupportedOSPlatform("windows")]
+#endif
 	sealed class SymbolWriterImpl : SymbolWriter {
 		readonly ISymUnmanagedWriter2 writer;
 		readonly ISymUnmanagedAsyncMethodPropertiesWriter asyncMethodWriter;

--- a/src/DotNet/Pdb/Managed/DbiModule.cs
+++ b/src/DotNet/Pdb/Managed/DbiModule.cs
@@ -157,7 +157,7 @@ namespace dnlib.DotNet.Pdb.Managed {
 			if (funcs[found].Lines is null) {
 				while (found > 0) {
 					var prevFunc = funcs[found - 1];
-					if (prevFunc is not null || prevFunc.Address != address)
+					if (prevFunc is not null && prevFunc.Address != address)
 						break;
 					found--;
 				}

--- a/src/DotNet/Pdb/Managed/DbiScope.cs
+++ b/src/DotNet/Pdb/Managed/DbiScope.cs
@@ -62,7 +62,7 @@ namespace dnlib.DotNet.Pdb.Managed {
 				Name = name;
 				Data = data;
 			}
-			public override string ToString() => Name + " = (" + Data.Length.ToString() + " bytes)";
+			public override string ToString() => $"{Name} = ({Data.Length} bytes)";
 		}
 
 		static readonly byte[] dotNetOemGuid = new byte[] {
@@ -116,7 +116,7 @@ namespace dnlib.DotNet.Pdb.Managed {
 						var data = reader.ReadBytes((int)(end - reader.Position));
 						if (oemInfos is null)
 							oemInfos = new List<OemInfo>(1);
-						oemInfos.Add(new OemInfo(name, data));	
+						oemInfos.Add(new OemInfo(name, data));
 						break;
 					case SymbolType.S_MANCONSTANT:
 						uint signatureToken = reader.ReadUInt32();

--- a/src/DotNet/Pdb/Managed/PdbException.cs
+++ b/src/DotNet/Pdb/Managed/PdbException.cs
@@ -20,7 +20,7 @@ namespace dnlib.DotNet.Pdb.Managed {
 		/// </summary>
 		/// <param name="message">Exception message</param>
 		public PdbException(string message)
-			: base("Failed to read PDB: " + message) {
+			: base($"Failed to read PDB: {message}") {
 		}
 
 		/// <summary>
@@ -28,7 +28,7 @@ namespace dnlib.DotNet.Pdb.Managed {
 		/// </summary>
 		/// <param name="innerException">Inner exception</param>
 		public PdbException(Exception innerException)
-			: base("Failed to read PDB: " + innerException.Message, innerException) {
+			: base($"Failed to read PDB: {innerException.Message}", innerException) {
 		}
 
 		/// <summary>

--- a/src/DotNet/Pdb/Managed/PdbReader.cs
+++ b/src/DotNet/Pdb/Managed/PdbReader.cs
@@ -263,7 +263,7 @@ namespace dnlib.DotNet.Pdb.Managed {
 			if (!documents.TryGetValue(name, out var doc)) {
 				doc = new DbiDocument(name);
 
-				if (names.TryGetValue("/src/files/" + name, out uint streamId))
+				if (names.TryGetValue($"/src/files/{name}", out uint streamId))
 					doc.Read(ref streams[streamId].Content);
 				documents.Add(name, doc);
 			}

--- a/src/DotNet/Pdb/PdbConstant.cs
+++ b/src/DotNet/Pdb/PdbConstant.cs
@@ -71,7 +71,10 @@ namespace dnlib.DotNet.Pdb {
 		/// <returns></returns>
 		public override string ToString() {
 			var type = Type;
-			return (type is null ? "" : type.ToString()) + " " + Name + " = " + (Value is null ? "null" : Value.ToString() + " (" + Value.GetType().FullName + ")");
+			var value = Value;
+			string typeString = type is null ? "" : type.ToString();
+			string valueString = value is null ? "null" : $"{value} ({value.GetType().FullName})";
+			return$"{typeString} {Name} = {valueString}";
 		}
 	}
 }

--- a/src/DotNet/Pdb/Portable/ImportDefinitionKindUtils.cs
+++ b/src/DotNet/Pdb/Portable/ImportDefinitionKindUtils.cs
@@ -19,7 +19,7 @@ namespace dnlib.DotNet.Pdb.Portable {
 			case 8:		return PdbImportDefinitionKind.AliasAssemblyNamespace;
 			case 9:		return PdbImportDefinitionKind.AliasType;
 			default:
-				Debug.Fail("Unknown import definition kind: 0x" + value.ToString("X"));
+				Debug.Fail($"Unknown import definition kind: 0x{value:X}");
 				return UNKNOWN_IMPORT_KIND;
 			}
 		}

--- a/src/DotNet/Pdb/Portable/ImportScopeBlobReader.cs
+++ b/src/DotNet/Pdb/Portable/ImportScopeBlobReader.cs
@@ -98,7 +98,7 @@ namespace dnlib.DotNet.Pdb.Portable {
 					break;
 
 				default:
-					Debug.Fail("Unknown import definition kind: " + kind.ToString());
+					Debug.Fail($"Unknown import definition kind: {kind}");
 					import = null;
 					break;
 				}

--- a/src/DotNet/Pdb/Portable/LocalConstantSigBlobReader.cs
+++ b/src/DotNet/Pdb/Portable/LocalConstantSigBlobReader.cs
@@ -233,7 +233,7 @@ namespace dnlib.DotNet.Pdb.Portable {
 			case ElementType.Sentinel:
 			case ElementType.Pinned:
 			default:
-				Debug.Fail("Unsupported element type in LocalConstant sig blob: " + et.ToString());
+				Debug.Fail($"Unsupported element type in LocalConstant sig blob: {et}");
 				res = false;
 				type = null;
 				value = null;

--- a/src/DotNet/Pdb/Portable/PortablePdbCustomDebugInfoReader.cs
+++ b/src/DotNet/Pdb/Portable/PortablePdbCustomDebugInfoReader.cs
@@ -71,7 +71,7 @@ namespace dnlib.DotNet.Pdb.Portable {
 				return ReadEncStateMachineStateMap();
 			if (kind == CustomDebugInfoGuids.PrimaryConstructorInformationBlob)
 				return ReadPrimaryConstructorInformationBlob();
-			Debug.Fail("Unknown custom debug info guid: " + kind.ToString());
+			Debug.Fail($"Unknown custom debug info guid: {kind}");
 			return new PdbUnknownCustomDebugInfo(kind, reader.ReadRemainingBytes());
 		}
 

--- a/src/DotNet/Pdb/Portable/PortablePdbReader.cs
+++ b/src/DotNet/Pdb/Portable/PortablePdbReader.cs
@@ -86,7 +86,7 @@ namespace dnlib.DotNet.Pdb.Portable {
 		bool TryGetSymbolDocument(uint rid, out SymbolDocument document) {
 			int index = (int)rid - 1;
 			if ((uint)index >= (uint)documents.Length) {
-				Debug.Fail("Couldn't find document with rid 0x" + rid.ToString("X6"));
+				Debug.Fail($"Couldn't find document with rid 0x{rid:X6}");
 				document = null;
 				return false;
 			}

--- a/src/DotNet/Pdb/SymbolReaderFactory.cs
+++ b/src/DotNet/Pdb/SymbolReaderFactory.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using dnlib.DotNet.MD;
 using dnlib.DotNet.Pdb.Symbols;
@@ -66,7 +67,13 @@ namespace dnlib.DotNet.Pdb {
 				if (!pdbContext.HasDebugInfo)
 					return null;
 
-				if ((pdbContext.Options & PdbReaderOptions.MicrosoftComReader) != 0 && pdbStream is not null && IsWindowsPdb(pdbStream.CreateReader()))
+#if NETSTANDARD || NETCOREAPP
+				var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#else
+				var isWindows = true;
+#endif
+
+				if ((pdbContext.Options & PdbReaderOptions.MicrosoftComReader) != 0 && isWindows && pdbStream is not null && IsWindowsPdb(pdbStream.CreateReader()))
 					symReader = Dss.SymbolReaderWriterFactory.Create(pdbContext, metadata, pdbStream);
 				else
 					symReader = CreateManaged(pdbContext, metadata, pdbStream);

--- a/src/DotNet/Pdb/WindowsPdb/PdbCustomDebugInfoReader.cs
+++ b/src/DotNet/Pdb/WindowsPdb/PdbCustomDebugInfoReader.cs
@@ -262,7 +262,7 @@ namespace dnlib.DotNet.Pdb.WindowsPdb {
 				return tupleListRec;
 
 			default:
-				Debug.Fail("Unknown custom debug info kind: 0x" + ((int)recKind).ToString("X"));
+				Debug.Fail($"Unknown custom debug info kind: 0x{(int)recKind:X}");
 				data = reader.ReadBytes((int)(recPosEnd - reader.Position));
 				return new PdbUnknownCustomDebugInfo(recKind, data);
 			}

--- a/src/DotNet/Resources/ResourceDataFactory.cs
+++ b/src/DotNet/Resources/ResourceDataFactory.cs
@@ -205,7 +205,9 @@ namespace dnlib.DotNet.Resources {
 			try {
 				var formatter = new BinaryFormatter();
 				formatter.Binder = new MyBinder();
+#pragma warning disable SYSLIB0011 // Type or member is obsolete
 				formatter.Deserialize(new MemoryStream(value));
+#pragma warning restore SYSLIB0011 // Type or member is obsolete
 			}
 			catch (MyBinder.OkException ex) {
 				assemblyName = ex.AssemblyName;

--- a/src/DotNet/Resources/ResourceWriter.cs
+++ b/src/DotNet/Resources/ResourceWriter.cs
@@ -46,7 +46,7 @@ namespace dnlib.DotNet.Resources {
 
 		void Write() {
 			if (resources.FormatVersion != 1 && resources.FormatVersion != 2)
-				throw new ArgumentException("Invalid format version: " + resources.FormatVersion, nameof(resources));
+				throw new ArgumentException($"Invalid format version: {resources.FormatVersion}", nameof(resources));
 
 			InitializeUserTypes(resources.FormatVersion);
 
@@ -145,7 +145,7 @@ namespace dnlib.DotNet.Resources {
 			}
 			else {
 				var mscorlibFullName = GetMscorlibFullname();
-				headerWriter.Write("System.Resources.ResourceReader, " + mscorlibFullName);
+				headerWriter.Write($"System.Resources.ResourceReader, {mscorlibFullName}");
 				headerWriter.Write("System.Resources.RuntimeResourceSet");
 			}
 			writer.Write((int)memStream.Position);

--- a/src/DotNet/Writer/ModuleWriterBase.cs
+++ b/src/DotNet/Writer/ModuleWriterBase.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using dnlib.DotNet.Pdb.WindowsPdb;
 using System.Text;
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 
 namespace dnlib.DotNet.Writer {
 	/// <summary>
@@ -943,6 +944,12 @@ namespace dnlib.DotNet.Writer {
 		}
 
 		SymbolWriter GetWindowsPdbSymbolWriter(PdbWriterOptions options, out string pdbFilename) {
+#if NETSTANDARD || NETCOREAPP
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+				pdbFilename = null;
+				return null;
+			}
+#endif
 			if (TheOptions.PdbStream is not null) {
 				return Pdb.Dss.SymbolReaderWriterFactory.Create(options, TheOptions.PdbStream,
 							pdbFilename = TheOptions.PdbFileName ??

--- a/src/IO/DataReader.cs
+++ b/src/IO/DataReader.cs
@@ -46,7 +46,7 @@ namespace dnlib.IO {
 				VerifyState();
 				if (value < startOffset || value > endOffset) {
 					// Invalid offsets should be an IOException and not an ArgumentException
-					ThrowDataReaderException("Invalid new " + nameof(CurrentOffset));
+					ThrowDataReaderException($"Invalid new {nameof(CurrentOffset)}");
 				}
 				currentOffset = value;
 				VerifyState();
@@ -62,7 +62,7 @@ namespace dnlib.IO {
 				VerifyState();
 				if (value > Length) {
 					// Invalid positions should be an IOException and not an ArgumentException
-					ThrowDataReaderException("Invalid new " + nameof(Position));
+					ThrowDataReaderException($"Invalid new {nameof(Position)}");
 				}
 				currentOffset = startOffset + value;
 				VerifyState();

--- a/src/IO/DataReaderFactoryFactory.cs
+++ b/src/IO/DataReaderFactoryFactory.cs
@@ -13,7 +13,7 @@ namespace dnlib.IO {
 			int p = (int)Environment.OSVersion.Platform;
 			if (p == 4 || p == 6 || p == 128)
 				isUnix = true;
-#if NETSTANDARD
+#if NETSTANDARD || NETCOREAPP
 			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 				isUnix = true;
 #endif

--- a/src/PE/ProcessorArchUtils.cs
+++ b/src/PE/ProcessorArchUtils.cs
@@ -16,7 +16,7 @@ namespace dnlib.PE {
 		}
 
 		static class RuntimeInformationUtils {
-#if NETSTANDARD
+#if NETSTANDARD || NETCOREAPP
 			public static bool TryGet_RuntimeInformation_Architecture(out Machine machine) =>
 				TryGetArchitecture((int)RuntimeInformation.ProcessArchitecture, out machine);
 #else

--- a/src/dnlib.csproj
+++ b/src/dnlib.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);$(MoreDefineConstants)</DefineConstants>
     <DefineConstants Condition=" '$(DnlibThreadSafe)' != 'false' ">$(DefineConstants);THREAD_SAFE</DefineConstants>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45;net6.0</TargetFrameworks>
     <!-- It's not possible to target .NET Framework 3.5 when using dotnet build
          https://github.com/Microsoft/msbuild/issues/1333 -->
     <NoTargetFrameworkNet35 Condition=" '$(NoTargetFrameworkNet35)' == '' AND '$(MSBuildRuntimeType)' == 'Core' ">true</NoTargetFrameworkNet35>

--- a/src/dnlib.csproj
+++ b/src/dnlib.csproj
@@ -59,8 +59,8 @@ For better *Windows PDB* writer support, you should add a reference to `Microsof
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
Fixes https://github.com/0xd4d/dnlib/issues/514

This PR adds support `net6.0` target for `dnlib`. The rationale for this change was discussed in the aforementioned issue and updates the NuGet packages used by `dnlib` to the latest available versions.

I've also gone ahead and replaced most of the usages of string concatenation and replaced it with string interpolation. This allows Roslyn to better take advantage of the faster string API's available in .NET 6. Some code changes were also necessary to resolve warnings regarding obsolete members and platform compatibility of the unmanaged Windows PDB support. A few NRE's which were picked up by code analysis were also fixed!
