### PR TITLE
Align field initial value to match the Microsoft's ECMA augments

### DIFF
--- a/Examples/Example6.cs
+++ b/Examples/Example6.cs
@@ -79,6 +79,7 @@ namespace dnlib.Examples {
 
 			public uint GetFileLength() => (uint)heapData.Length;
 			public uint GetVirtualSize() => GetFileLength();
+			public uint CalculateAlignment() => 0;
 			public void WriteTo(DataWriter writer) => writer.WriteBytes(heapData);
 		}
 

--- a/src/DotNet/Utils.cs
+++ b/src/DotNet/Utils.cs
@@ -316,5 +316,19 @@ namespace dnlib.DotNet {
 		/// <param name="v">Value</param>
 		/// <param name="alignment">Alignment</param>
 		public static int AlignUp(int v, uint alignment) => (int)AlignUp((uint)v, alignment);
+
+		/// <summary>
+		/// Rounds up the provided number to the next power of 2
+		/// </summary>
+		/// <param name="num">The number to round</param>
+		public static uint RoundToNextPowerOfTwo(uint num) {
+			num--;
+			num |= num >> 1;
+			num |= num >> 2;
+			num |= num >> 4;
+			num |= num >> 8;
+			num |= num >> 16;
+			return num + 1;
+		}
 	}
 }

--- a/src/DotNet/Writer/ArrayWriter.cs
+++ b/src/DotNet/Writer/ArrayWriter.cs
@@ -11,7 +11,10 @@ namespace dnlib.DotNet.Writer {
 		/// <summary>
 		/// Gets the current position
 		/// </summary>
-		public int Position => position;
+		public int Position {
+			get => position;
+			set => position = value;
+		}
 
 		readonly byte[] data;
 		int position;

--- a/src/DotNet/Writer/ByteArrayChunk.cs
+++ b/src/DotNet/Writer/ByteArrayChunk.cs
@@ -10,6 +10,7 @@ namespace dnlib.DotNet.Writer {
 	/// </summary>
 	public sealed class ByteArrayChunk : IReuseChunk {
 		readonly byte[] array;
+		readonly uint alignment;
 		FileOffset offset;
 		RVA rva;
 
@@ -32,7 +33,11 @@ namespace dnlib.DotNet.Writer {
 		/// <see cref="GetHashCode"/> return value will be different if you modify the array). If
 		/// it's never inserted as a <c>key</c> in a dictionary, then the contents can be modified,
 		/// but shouldn't be resized after <see cref="SetOffset"/> has been called.</param>
-		public ByteArrayChunk(byte[] array) => this.array = array ?? Array2.Empty<byte>();
+		/// <param name="alignment">The alignment of the data</param>
+		public ByteArrayChunk(byte[] array, uint alignment = 0) {
+			this.array = array ?? Array2.Empty<byte>();
+			this.alignment = alignment;
+		}
 
 		bool IReuseChunk.CanReuse(RVA origRva, uint origSize) => (uint)array.Length <= origSize;
 
@@ -47,6 +52,9 @@ namespace dnlib.DotNet.Writer {
 
 		/// <inheritdoc/>
 		public uint GetVirtualSize() => GetFileLength();
+
+		/// <inheritdoc/>
+		public uint CalculateAlignment() => alignment;
 
 		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) => writer.WriteBytes(array);

--- a/src/DotNet/Writer/ChunkListBase.cs
+++ b/src/DotNet/Writer/ChunkListBase.cs
@@ -1,5 +1,6 @@
 // dnlib: See LICENSE.txt for more info
 
+using System;
 using System.Collections.Generic;
 using dnlib.IO;
 using dnlib.PE;
@@ -113,6 +114,20 @@ namespace dnlib.DotNet.Writer {
 				elem.chunk.VerifyWriteTo(writer);
 				offset2 += (uint)paddingF + elem.chunk.GetFileLength();
 			}
+		}
+
+		/// <inheritdoc/>
+		public virtual uint CalculateAlignment() {
+			uint alignment = 0;
+			for (int i = 0; i < chunks.Count; i++) {
+				var elem = chunks[i];
+				uint newAlignment = Math.Max(elem.alignment, elem.chunk.CalculateAlignment());
+				chunks[i] = new Elem(elem.chunk, newAlignment);
+
+				alignment = Math.Max(alignment, newAlignment);
+			}
+
+			return alignment;
 		}
 	}
 }

--- a/src/DotNet/Writer/DataReaderChunk.cs
+++ b/src/DotNet/Writer/DataReaderChunk.cs
@@ -87,6 +87,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => virtualSize;
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			data.Position = 0;
 			data.CopyTo(writer);

--- a/src/DotNet/Writer/DebugDirectory.cs
+++ b/src/DotNet/Writer/DebugDirectory.cs
@@ -140,6 +140,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			uint offset = 0;
 			foreach (var entry in entries) {

--- a/src/DotNet/Writer/HeapBase.cs
+++ b/src/DotNet/Writer/HeapBase.cs
@@ -51,6 +51,9 @@ namespace dnlib.DotNet.Writer {
 		/// <inheritdoc/>
 		public uint GetVirtualSize() => GetFileLength();
 
+		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
 		/// <summary>
 		/// Gets the raw length of the heap
 		/// </summary>

--- a/src/DotNet/Writer/IChunk.cs
+++ b/src/DotNet/Writer/IChunk.cs
@@ -41,6 +41,13 @@ namespace dnlib.DotNet.Writer {
 		uint GetVirtualSize();
 
 		/// <summary>
+		/// Calculates the requires alignment of this chunk.
+		/// Returns 0 for default/no alignment.
+		/// </summary>
+		/// <returns>Required alignment</returns>
+		uint CalculateAlignment();
+
+		/// <summary>
 		/// Writes all data to <paramref name="writer"/> at its current location. It's only
 		/// called after <see cref="SetOffset"/> and <see cref="GetFileLength"/> have been called.
 		/// You cannot assume that <paramref name="writer"/>'s file position is the same as this

--- a/src/DotNet/Writer/ImageCor20Header.cs
+++ b/src/DotNet/Writer/ImageCor20Header.cs
@@ -114,6 +114,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			writer.WriteInt32(0x48);	// cb
 			writer.WriteUInt16(options.MajorRuntimeVersion ?? Cor20HeaderOptions.DEFAULT_MAJOR_RT_VER);

--- a/src/DotNet/Writer/ImportAddressTable.cs
+++ b/src/DotNet/Writer/ImportAddressTable.cs
@@ -48,6 +48,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			if (!Enable)
 				return;

--- a/src/DotNet/Writer/ImportDirectory.cs
+++ b/src/DotNet/Writer/ImportDirectory.cs
@@ -105,6 +105,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			if (!Enable)
 				return;

--- a/src/DotNet/Writer/ManagedExportsWriter.cs
+++ b/src/DotNet/Writer/ManagedExportsWriter.cs
@@ -44,6 +44,7 @@ namespace dnlib.DotNet.Writer {
 			void IChunk.SetOffset(FileOffset offset, RVA rva) => throw new NotSupportedException();
 			public uint GetFileLength() => owner.ExportDirSize;
 			public uint GetVirtualSize() => GetFileLength();
+			public uint CalculateAlignment() => 0;
 			void IChunk.WriteTo(DataWriter writer) => throw new NotSupportedException();
 		}
 
@@ -61,6 +62,7 @@ namespace dnlib.DotNet.Writer {
 			}
 			public uint GetFileLength() => length;
 			public uint GetVirtualSize() => GetFileLength();
+			public uint CalculateAlignment() => 0;
 			public void WriteTo(DataWriter writer) => owner.WriteVtableFixups(writer);
 		}
 
@@ -78,6 +80,7 @@ namespace dnlib.DotNet.Writer {
 			}
 			public uint GetFileLength() => length;
 			public uint GetVirtualSize() => GetFileLength();
+			public uint CalculateAlignment() => 0;
 			public void WriteTo(DataWriter writer) => owner.WriteStubs(writer);
 		}
 
@@ -95,6 +98,7 @@ namespace dnlib.DotNet.Writer {
 			}
 			public uint GetFileLength() => length;
 			public uint GetVirtualSize() => GetFileLength();
+			public uint CalculateAlignment() => 0;
 			public void WriteTo(DataWriter writer) => owner.WriteSdata(writer);
 		}
 

--- a/src/DotNet/Writer/Metadata.cs
+++ b/src/DotNet/Writer/Metadata.cs
@@ -3775,6 +3775,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			var rva2 = rva;
 			metadataHeader.VerifyWriteTo(writer);

--- a/src/DotNet/Writer/Metadata.cs
+++ b/src/DotNet/Writer/Metadata.cs
@@ -2708,7 +2708,7 @@ namespace dnlib.DotNet.Writer {
 				uint alignment = ModuleWriterBase.DEFAULT_CONSTANTS_ALIGNMENT;
 				const uint MaxFieldInitialValueAlignment = 1024U;
 				if (field.FieldType is TypeDefOrRefSig tdrSig && tdrSig.TypeDef?.ClassLayout is {} classLayout) {
-					uint requiredAlignment = Math.Min(RoundUpToPowerOfTwo(classLayout.PackingSize), MaxFieldInitialValueAlignment);
+					uint requiredAlignment = Math.Min(Utils.RoundToNextPowerOfTwo(classLayout.PackingSize), MaxFieldInitialValueAlignment);
 					alignment = Math.Max(alignment, requiredAlignment);
 				}
 
@@ -2726,16 +2726,6 @@ namespace dnlib.DotNet.Writer {
 			if (sig is null)
 				return false;
 			return field.GetFieldSize() == size;
-		}
-
-		static uint RoundUpToPowerOfTwo(uint num) {
-			num--;
-			num |= num >> 1;
-			num |= num >> 2;
-			num |= num >> 4;
-			num |= num >> 8;
-			num |= num >> 16;
-			return num + 1;
 		}
 
 		/// <summary>

--- a/src/DotNet/Writer/Metadata.cs
+++ b/src/DotNet/Writer/Metadata.cs
@@ -2708,7 +2708,7 @@ namespace dnlib.DotNet.Writer {
 				uint alignment = ModuleWriterBase.DEFAULT_CONSTANTS_ALIGNMENT;
 				const uint MaxFieldInitialValueAlignment = 1024U;
 				if (field.FieldType is TypeDefOrRefSig tdrSig && tdrSig.TypeDef?.ClassLayout is {} classLayout) {
-					uint requiredAlignment = Math.Max(RoundUpToPowerOfTwo(classLayout.PackingSize), MaxFieldInitialValueAlignment);
+					uint requiredAlignment = Math.Min(RoundUpToPowerOfTwo(classLayout.PackingSize), MaxFieldInitialValueAlignment);
 					alignment = Math.Max(alignment, requiredAlignment);
 				}
 

--- a/src/DotNet/Writer/Metadata.cs
+++ b/src/DotNet/Writer/Metadata.cs
@@ -2706,11 +2706,8 @@ namespace dnlib.DotNet.Writer {
 				uint rid = GetRid(field);
 
 				uint alignment = ModuleWriterBase.DEFAULT_CONSTANTS_ALIGNMENT;
-				const uint MaxFieldInitialValueAlignment = 1024U;
-				if (field.FieldType is TypeDefOrRefSig tdrSig && tdrSig.TypeDef?.ClassLayout is {} classLayout) {
-					uint requiredAlignment = Math.Min(Utils.RoundToNextPowerOfTwo(classLayout.PackingSize), MaxFieldInitialValueAlignment);
-					alignment = Math.Max(alignment, requiredAlignment);
-				}
+				if (field.FieldType is TypeDefOrRefSig tdrSig && tdrSig.TypeDef?.ClassLayout is {} classLayout)
+					alignment = Math.Max(alignment, Utils.RoundToNextPowerOfTwo(classLayout.PackingSize));
 
 				var iv = constants.Add(new ByteArrayChunk(ivBytes, alignment), alignment);
 				fieldToInitialValue[field] = iv;

--- a/src/DotNet/Writer/MetadataHeader.cs
+++ b/src/DotNet/Writer/MetadataHeader.cs
@@ -136,6 +136,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			writer.WriteUInt32(options.Signature ?? MetadataHeaderOptions.DEFAULT_SIGNATURE);
 			writer.WriteUInt16(options.MajorVersion ?? 1);

--- a/src/DotNet/Writer/MethodBody.cs
+++ b/src/DotNet/Writer/MethodBody.cs
@@ -133,6 +133,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			writer.WriteBytes(code);
 			if (HasExtraSections) {

--- a/src/DotNet/Writer/MethodBodyChunks.cs
+++ b/src/DotNet/Writer/MethodBodyChunks.cs
@@ -172,6 +172,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			var rva2 = rva;
 			foreach (var mb in tinyMethods) {

--- a/src/DotNet/Writer/ModuleWriterBase.cs
+++ b/src/DotNet/Writer/ModuleWriterBase.cs
@@ -785,6 +785,8 @@ namespace dnlib.DotNet.Writer {
 			int count = chunks.Count;
 			for (int i = 0; i < count; i++) {
 				var chunk = chunks[i];
+				// TODO: We should probably align the offset and RVA here to the chunk's required alignment!
+				chunk.CalculateAlignment();
 				chunk.SetOffset(offset, rva);
 				// If it has zero size, it's not present in the file (eg. a section that wasn't needed)
 				if (chunk.GetVirtualSize() != 0) {

--- a/src/DotNet/Writer/ModuleWriterBase.cs
+++ b/src/DotNet/Writer/ModuleWriterBase.cs
@@ -783,10 +783,15 @@ namespace dnlib.DotNet.Writer {
 		/// <param name="sectionAlignment">Section alignment</param>
 		protected void CalculateRvasAndFileOffsets(List<IChunk> chunks, FileOffset offset, RVA rva, uint fileAlignment, uint sectionAlignment) {
 			int count = chunks.Count;
+			var maxAlignment = Math.Min(fileAlignment, sectionAlignment);
 			for (int i = 0; i < count; i++) {
 				var chunk = chunks[i];
-				// TODO: We should probably align the offset and RVA here to the chunk's required alignment!
-				chunk.CalculateAlignment();
+				// We don't need to align to result of CalculateAlignment as all the chunks in `chunks` either
+				// don't need a specific alignment or align themselves.
+				var alignment = chunk.CalculateAlignment();
+				if (alignment > maxAlignment)
+					Error("Chunk alignment is too big. Chunk: {0}, alignment: {1:X4}", chunk, alignment);
+
 				chunk.SetOffset(offset, rva);
 				// If it has zero size, it's not present in the file (eg. a section that wasn't needed)
 				if (chunk.GetVirtualSize() != 0) {

--- a/src/DotNet/Writer/NetResources.cs
+++ b/src/DotNet/Writer/NetResources.cs
@@ -75,6 +75,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			var rva2 = rva;
 			foreach (var resourceData in resources) {

--- a/src/DotNet/Writer/PEHeaders.cs
+++ b/src/DotNet/Writer/PEHeaders.cs
@@ -325,6 +325,9 @@ namespace dnlib.DotNet.Writer {
 		/// <inheritdoc/>
 		public uint GetVirtualSize() => GetFileLength();
 
+		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
 		IEnumerable<SectionSizeInfo> GetSectionSizeInfos() {
 			foreach (var section in sections) {
 				uint virtSize = section.GetVirtualSize();

--- a/src/DotNet/Writer/RelocDirectory.cs
+++ b/src/DotNet/Writer/RelocDirectory.cs
@@ -82,6 +82,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			bool is64bit = machine.Is64Bit();
 			// 3 = IMAGE_REL_BASED_HIGHLOW, A = IMAGE_REL_BASED_DIR64

--- a/src/DotNet/Writer/StartupStub.cs
+++ b/src/DotNet/Writer/StartupStub.cs
@@ -83,6 +83,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			if (!Enable)
 				return;

--- a/src/DotNet/Writer/StrongNameSignature.cs
+++ b/src/DotNet/Writer/StrongNameSignature.cs
@@ -39,6 +39,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) => writer.WriteZeroes(size);
 	}
 }

--- a/src/DotNet/Writer/TablesHeap.cs
+++ b/src/DotNet/Writer/TablesHeap.cs
@@ -331,6 +331,9 @@ namespace dnlib.DotNet.Writer {
 		/// <inheritdoc/>
 		public uint GetVirtualSize() => GetFileLength();
 
+		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
 		/// <summary>
 		/// Calculates the length. This will set all MD tables to read-only.
 		/// </summary>

--- a/src/DotNet/Writer/UniqueChunkList.cs
+++ b/src/DotNet/Writer/UniqueChunkList.cs
@@ -53,5 +53,17 @@ namespace dnlib.DotNet.Writer {
 			chunks.Add(elem);
 			return elem.chunk;
 		}
+
+		/// <inheritdoc/>
+		public override uint CalculateAlignment() {
+			uint alignment = base.CalculateAlignment();
+			chunks.Sort(DescendingComparer.Instance);
+			return alignment;
+		}
+
+		class DescendingComparer : IComparer<Elem> {
+			internal static readonly DescendingComparer Instance = new DescendingComparer();
+			public int Compare(Elem x, Elem y) => -x.alignment.CompareTo(y.alignment);
+		}
 	}
 }

--- a/src/DotNet/Writer/UniqueChunkList.cs
+++ b/src/DotNet/Writer/UniqueChunkList.cs
@@ -57,13 +57,26 @@ namespace dnlib.DotNet.Writer {
 		/// <inheritdoc/>
 		public override uint CalculateAlignment() {
 			uint alignment = base.CalculateAlignment();
-			chunks.Sort(DescendingComparer.Instance);
+
+			var keys = new KeyValuePair<int, Elem>[chunks.Count];
+			for (var i = 0; i < chunks.Count; i++)
+				keys[i] = new KeyValuePair<int, Elem>(i, chunks[i]);
+			Array.Sort(keys, DescendingStableComparer.Instance);
+			for (var i = 0; i < keys.Length; i++)
+				chunks[i] = keys[i].Value;
+
 			return alignment;
 		}
 
-		class DescendingComparer : IComparer<Elem> {
-			internal static readonly DescendingComparer Instance = new DescendingComparer();
-			public int Compare(Elem x, Elem y) => -x.alignment.CompareTo(y.alignment);
+		sealed class DescendingStableComparer : IComparer<KeyValuePair<int, Elem>> {
+			internal static readonly DescendingStableComparer Instance = new DescendingStableComparer();
+
+			public int Compare(KeyValuePair<int, Elem> x, KeyValuePair<int, Elem> y) {
+				var result = -x.Value.alignment.CompareTo(y.Value.alignment);
+				if (result != 0)
+					return result;
+				return x.Key.CompareTo(y.Key);
+			}
 		}
 	}
 }

--- a/src/DotNet/Writer/Win32ResourcesChunk.cs
+++ b/src/DotNet/Writer/Win32ResourcesChunk.cs
@@ -354,6 +354,9 @@ namespace dnlib.DotNet.Writer {
 		public uint GetVirtualSize() => GetFileLength();
 
 		/// <inheritdoc/>
+		public uint CalculateAlignment() => 0;
+
+		/// <inheritdoc/>
 		public void WriteTo(DataWriter writer) {
 			uint offset = 0;
 


### PR DESCRIPTION
Current changes:
* Added `ArrayWriter.Position` setter (not really related to this PR but thought I would squeeze it in, makes consuming the class more pleasant)
* Added `IChunk.CalculateAlignement` method to calculate the required alignment of a specific chunk.
* Extended `ByteArrayChunk` constructor to accept required alignment.

Things left to do:
- [x] Calculate the alignment for the field initial values and pass them to `ByteArrayChunk`
- [x] ~~Consider extending other chunks like `DataReaderChunk` with customizable alignment.~~ (After further consideration I don't think this is needed, the user can just implement it themselves)
- [x] ~~Modify `CalculateRvasAndFileOffsets` to align the RVA and FileOffset to the chunk's required alignment, so that the return value of the method is respected outside of `ChunkListBase<T>` as well.~~ (see comment https://github.com/0xd4d/dnlib/pull/518#issuecomment-1660965348)
- [x] Implement some sort of sorting to either `ChunkListBase<T>`, `UniqueChunkList`, or add a new intermediary class `SortedChunkList<T>` to optimize the chunk positions for their alignment. An open question is also how should we sort the data for optimal file size
- [x] Run tests to see if the implementation works :p

I've also been wondering if chunks like `StrongNameSignature` or `Win32ResourcesChunk` should define a `CalculateAlignment` which returns the default alignments used when adding them to their respective chunk lists to better reflect the alignment they necessitate to the user.

fixes #454 