### PR TITLE
Fix incorrect column sizes when writing portable or embedded PDB files

### DIFF
--- a/src/DotNet/Writer/TablesHeap.cs
+++ b/src/DotNet/Writer/TablesHeap.cs
@@ -353,7 +353,19 @@ namespace dnlib.DotNet.Writer {
 			var dnTableSizes = new DotNetTableSizes();
 			var tableInfos = dnTableSizes.CreateTables(majorVersion, minorVersion);
 			var rowCounts = GetRowCounts();
-			dnTableSizes.InitializeSizes(bigStrings, bigGuid, bigBlob, systemTables ?? rowCounts, rowCounts, options.ForceBigColumns ?? false);
+
+			var debugSizes = rowCounts;
+			if (systemTables is not null) {
+				debugSizes = new uint[rowCounts.Length];
+				for (int i = 0; i < rowCounts.Length; i++) {
+					if (DotNetTableSizes.IsSystemTable((Table)i))
+						debugSizes[i] = systemTables[i];
+					else
+						debugSizes[i] = rowCounts[i];
+				}
+			}
+
+			dnTableSizes.InitializeSizes(bigStrings, bigGuid, bigBlob, rowCounts, debugSizes, options.ForceBigColumns ?? false);
 			for (int i = 0; i < Tables.Length; i++)
 				Tables[i].TableInfo = tableInfos[i];
 


### PR DESCRIPTION
Fixes https://github.com/0xd4d/dnlib/issues/530

The fix was implemented by adjusting the row counts passed into the `InitializeSizes` to fix a bug where the row counts were incorrect. The patch is heavily based on the code from `TablesStream`:
https://github.com/0xd4d/dnlib/blob/67396c0e5c3a8c27ac220aa5b3692fcf49f44ebf/src/DotNet/MD/TablesStream.cs#L254-L265