### PR TITLE
Check overlaps

### DIFF
--- a/src/DotNet/Writer/NativeModuleWriter.cs
+++ b/src/DotNet/Writer/NativeModuleWriter.cs
@@ -354,6 +354,12 @@ namespace dnlib.DotNet.Writer {
 			if (((uint)origRva & (requiredAlignment - 1)) != 0)
 				return;
 
+			var origEnd = origRva + origSize;
+			foreach (var reusedChunk in reusedChunks) {
+				if (origRva < reusedChunk.RVA + reusedChunk.Chunk.GetVirtualSize() && origEnd > reusedChunk.RVA)
+					return;
+			}
+
 			if (section.Remove(chunk) is null)
 				throw new InvalidOperationException();
 			reusedChunks.Add(new ReusedChunkInfo(chunk, origRva));


### PR DESCRIPTION
When I saved a file, I got an invalid .NET file, since COR20 header signature is rewritten.