### PR TITLE
Clean moduleSearchPaths

### DIFF
--- a/src/DotNet/AssemblyResolver.cs
+++ b/src/DotNet/AssemblyResolver.cs
@@ -336,6 +336,8 @@ namespace dnlib.DotNet {
 #if THREAD_SAFE
 			theLock.EnterWriteLock(); try {
 #endif
+			if (asm.ManifestModule is { } module)
+				moduleSearchPaths.Remove(module);
 			return cachedAssemblies.Remove(asmKey);
 #if THREAD_SAFE
 			} finally { theLock.ExitWriteLock(); }
@@ -355,6 +357,7 @@ namespace dnlib.DotNet {
 #endif
 			asms = new List<AssemblyDef>(cachedAssemblies.Values);
 			cachedAssemblies.Clear();
+		    moduleSearchPaths.Clear();
 #if THREAD_SAFE
 			} finally { theLock.ExitWriteLock(); }
 #endif


### PR DESCRIPTION
By the way, is there any issue in .editorconfig file? The code is always changed when formating (Ctrl + E, D)