### PR TITLE
Add ImportAsOperand to fix DynamicMethodBodyReader

### DIFF
--- a/src/DotNet/Emit/DynamicMethodBodyReader.cs
+++ b/src/DotNet/Emit/DynamicMethodBodyReader.cs
@@ -458,22 +458,22 @@ namespace dnlib.DotNet.Emit {
 				if ((options & DynamicMethodBodyReaderOptions.UnknownDeclaringType) != 0) {
 					// Sometimes it's a generic type but obj != `GenericMethodInfo`, so pass in 'default' and the
 					// runtime will try to figure out the declaring type. https://github.com/0xd4d/dnlib/issues/298
-					return importer.Import(SR.MethodBase.GetMethodFromHandle((RuntimeMethodHandle)obj, default));
+					return importer.ImportAsOperand(SR.MethodBase.GetMethodFromHandle((RuntimeMethodHandle)obj, default));
 				}
 				else
-					return importer.Import(SR.MethodBase.GetMethodFromHandle((RuntimeMethodHandle)obj));
+					return importer.ImportAsOperand(SR.MethodBase.GetMethodFromHandle((RuntimeMethodHandle)obj));
 			}
 
 			if (obj.GetType().ToString() == "System.Reflection.Emit.GenericMethodInfo") {
 				var context = (RuntimeTypeHandle)gmiContextFieldInfo.Read(obj);
 				var method = SR.MethodBase.GetMethodFromHandle((RuntimeMethodHandle)gmiMethodHandleFieldInfo.Read(obj), context);
-				return importer.Import(method);
+				return importer.ImportAsOperand(method);
 			}
 
 			if (obj.GetType().ToString() == "System.Reflection.Emit.VarArgMethod") {
 				var method = GetVarArgMethod(obj);
 				if (!(method is DynamicMethod))
-					return importer.Import(method);
+					return importer.ImportAsOperand(method);
 				obj = method;
 			}
 
@@ -506,16 +506,16 @@ namespace dnlib.DotNet.Emit {
 				if ((options & DynamicMethodBodyReaderOptions.UnknownDeclaringType) != 0) {
 					// Sometimes it's a generic type but obj != `GenericFieldInfo`, so pass in 'default' and the
 					// runtime will try to figure out the declaring type. https://github.com/0xd4d/dnlib/issues/298
-					return importer.Import(SR.FieldInfo.GetFieldFromHandle((RuntimeFieldHandle)obj, default));
+					return importer.ImportAsOperand(SR.FieldInfo.GetFieldFromHandle((RuntimeFieldHandle)obj, default));
 				}
 				else
-					return importer.Import(SR.FieldInfo.GetFieldFromHandle((RuntimeFieldHandle)obj));
+					return importer.ImportAsOperand(SR.FieldInfo.GetFieldFromHandle((RuntimeFieldHandle)obj));
 			}
 
 			if (obj.GetType().ToString() == "System.Reflection.Emit.GenericFieldInfo") {
 				var context = (RuntimeTypeHandle)gfiContextFieldInfo.Read(obj);
 				var field = SR.FieldInfo.GetFieldFromHandle((RuntimeFieldHandle)gfiFieldHandleFieldInfo.Read(obj), context);
-				return importer.Import(field);
+				return importer.ImportAsOperand(field);
 			}
 
 			return null;
@@ -524,7 +524,7 @@ namespace dnlib.DotNet.Emit {
 		ITypeDefOrRef ImportType(uint rid) {
 			var obj = Resolve(rid);
 			if (obj is RuntimeTypeHandle)
-				return importer.Import(Type.GetTypeFromHandle((RuntimeTypeHandle)obj));
+				return importer.ImportAsOperand(Type.GetTypeFromHandle((RuntimeTypeHandle)obj));
 
 			return null;
 		}

--- a/src/DotNet/Emit/DynamicMethodBodyReader.cs
+++ b/src/DotNet/Emit/DynamicMethodBodyReader.cs
@@ -420,16 +420,16 @@ namespace dnlib.DotNet.Emit {
 		protected override string ReadInlineString(Instruction instr) => ReadToken(reader.ReadUInt32()) as string ?? string.Empty;
 
 		/// <inheritdoc/>
-		protected override ITokenOperand ReadInlineTok(Instruction instr) => ReadToken(reader.ReadUInt32()) as ITokenOperand;
+		protected override ITokenOperand ReadInlineTok(Instruction instr) => ReadToken(reader.ReadUInt32(), true) as ITokenOperand;
 
 		/// <inheritdoc/>
 		protected override ITypeDefOrRef ReadInlineType(Instruction instr) => ReadToken(reader.ReadUInt32()) as ITypeDefOrRef;
 
-		object ReadToken(uint token) {
+		object ReadToken(uint token, bool ldtoken = false) {
 			uint rid = token & 0x00FFFFFF;
 			switch (token >> 24) {
 			case 0x02:
-				return ImportType(rid);
+				return ImportType(rid, ldtoken);
 
 			case 0x04:
 				return ImportField(rid);
@@ -521,10 +521,13 @@ namespace dnlib.DotNet.Emit {
 			return null;
 		}
 
-		ITypeDefOrRef ImportType(uint rid) {
+		ITypeDefOrRef ImportType(uint rid, bool ldtoken) {
 			var obj = Resolve(rid);
-			if (obj is RuntimeTypeHandle)
+			if (obj is RuntimeTypeHandle) {
+				if (ldtoken)
+					return importer.Import(Type.GetTypeFromHandle((RuntimeTypeHandle)obj));
 				return importer.ImportAsOperand(Type.GetTypeFromHandle((RuntimeTypeHandle)obj));
+			}
 
 			return null;
 		}


### PR DESCRIPTION
Not every issue is produced from #452 #466, some issues exist a long time, close #551

[DynamicTest.zip](https://github.com/0xd4d/dnlib/files/14884743/DynamicTest.zip)

Test code:
```c#
class Program
{
    public static void Main()
    {
        var module = ModuleDefMD.Load(typeof(Program).Assembly.Location);
        module.Context = ModuleDef.CreateModuleContext();
        var mi = typeof(My<>).GetMethod("Test");
        var md = (MethodDef)module.ResolveToken(mi.MetadataToken);
        var dm = DynamicMethodHelper.ConvertFrom(mi);
        dm.GetType().GetMethod("GetMethodDescriptor", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(dm, null);
        var dmr = new DynamicMethodBodyReader(module, dm, new Importer(module, ImporterOptions.TryToUseDefs, GenericParamContext.Create(md)), DynamicMethodBodyReaderOptions.UnknownDeclaringType);
        dmr.Read();
        var instrs = dmr.Instructions;
        var exceptions = dmr.ExceptionHandlers;
        var locals = dmr.Locals;
        Console.WriteLine("OK");
        Console.Read();
    }
}

class My<T> : Exception where T : Exception
{
    public static T StaticField;
    public T InstanceField;

    public static void Test()
    {
        try
        {
            Console.WriteLine(typeof(T));
            Console.WriteLine(typeof(My<T>));
            Console.WriteLine(StaticField);
            Console.WriteLine(My<Exception>.StaticField);
            Console.WriteLine(new My<Exception>().InstanceField);
            Console.WriteLine(new My<T>().InstanceField);
            Activator.CreateInstance<T>();
            Activator.CreateInstance<My<T>>();
            Static();
            GenericStatic(StaticField);
            new My<Exception>().Instance();
            new My<Exception>().GenericInstance("");
            new My<T>().Instance();
            new My<T>().GenericInstance("");
            new List<T>().Add(default);
            new List<int>().Add(0);
        }
        catch (My<T> ex)
        {
        }
        catch (My<Exception> ex)
        {
        }
        catch (T ex)
        {
        }
    }

    public static void Static() { }

    public static void GenericStatic<U>(U a) { }

    public void Instance() { }

    public void GenericInstance<U>(U a) { }
}
```
