### PR TITLE
Allow open generic in dynamic method (experimental, not a legal operation, with unpredictable problems)

### DIFF
--- a/src/DotNet/Emit/DynamicMethodBodyReader.cs
+++ b/src/DotNet/Emit/DynamicMethodBodyReader.cs
@@ -420,16 +420,16 @@ namespace dnlib.DotNet.Emit {
 		protected override string ReadInlineString(Instruction instr) => ReadToken(reader.ReadUInt32()) as string ?? string.Empty;
 
 		/// <inheritdoc/>
-		protected override ITokenOperand ReadInlineTok(Instruction instr) => ReadToken(reader.ReadUInt32()) as ITokenOperand;
+		protected override ITokenOperand ReadInlineTok(Instruction instr) => ReadToken(reader.ReadUInt32(), false) as ITokenOperand;
 
 		/// <inheritdoc/>
 		protected override ITypeDefOrRef ReadInlineType(Instruction instr) => ReadToken(reader.ReadUInt32()) as ITypeDefOrRef;
 
-		object ReadToken(uint token) {
+		object ReadToken(uint token, bool? treatAsGenericInst = null) {
 			uint rid = token & 0x00FFFFFF;
 			switch (token >> 24) {
 			case 0x02:
-				return ImportType(rid);
+				return ImportType(rid, treatAsGenericInst);
 
 			case 0x04:
 				return ImportField(rid);
@@ -521,10 +521,10 @@ namespace dnlib.DotNet.Emit {
 			return null;
 		}
 
-		ITypeDefOrRef ImportType(uint rid) {
+		ITypeDefOrRef ImportType(uint rid, bool? treatAsGenericInst = null) {
 			var obj = Resolve(rid);
 			if (obj is RuntimeTypeHandle)
-				return importer.Import(Type.GetTypeFromHandle((RuntimeTypeHandle)obj));
+				return importer.Import(Type.GetTypeFromHandle((RuntimeTypeHandle)obj), treatAsGenericInst);
 
 			return null;
 		}


### PR DESCRIPTION
Fix https://github.com/0xd4d/dnlib/issues/551

Test code for dynamic method with open generic:
[DynamicTest.zip](https://github.com/0xd4d/dnlib/files/15244267/DynamicTest.zip)

Test code for normal importing:
See https://github.com/0xd4d/dnlib/pull/466

Description:
This PR introduces a new constructor for Importer to enable open generic in dynamic method supporting.
When pass a non-null value to the new parameter 'originalDeclaringType', this PR is enabled. It changes some importing behavior to be compatible with illegal open generic dynamic methods.
This PR does not introduce other API changes (including additions, deletions, behavior changes), and will not have any impact on normal importing.

Known issues:
Due to quirks of the .NET reflection system, it is impossible to distinguish whether the operand in ldtoken is a typedef or a typespec when open generics exist. To keep normal importing behavior can get correct result of ldtoken typedef, when open generics exist and it is impossible to distinguish between typedef and typespec, they are uniformly imported as typedef.
``` cs
void Method<T>()
{
_ = typeof(List<>);
_ = typeof(List<T>);
}
```

Test code in DynamicTest.zip if you don't want to download it.
``` cs
class Program
{
    public static void Main()
    {
        var module = ModuleDefMD.Load(typeof(Program).Assembly.Location);
        module.Context = ModuleDef.CreateModuleContext();
        var mi = typeof(My<,>).GetMethod("Test");
        var md = (MethodDef)module.ResolveToken(mi.MetadataToken);
        var dm = DynamicMethodHelper.ConvertFrom(mi);
        dm.GetType().GetMethod("GetMethodDescriptor", BindingFlags.NonPublic | BindingFlags.Instance).Invoke(dm, null);
        var dmr = new DynamicMethodBodyReader(module, dm, new Importer(module, ImporterOptions.TryToUseDefs, GenericParamContext.Create(md), null, typeof(My<,>)), DynamicMethodBodyReaderOptions.UnknownDeclaringType);
        dmr.Read();
        var instrs = dmr.Instructions;
        instrs.SimplifyMacros(dmr.Locals, dmr.Parameters);
        var origInstrs = md.Body.Instructions;
        origInstrs.SimplifyMacros(md.Body.Variables, md.Parameters);
        var comparer = new SigComparer(SigComparerOptions.DontCompareTypeScope | SigComparerOptions.CompareMethodFieldDeclaringType | SigComparerOptions.IgnoreModifiers);
        for (int i = 0; i < instrs.Count; i++)
        {
            var instr = instrs[i];
            var origInstr = origInstrs[i];
            Console.WriteLine(instr);
            bool b = instr.OpCode == origInstr.OpCode;
            Debug.Assert(b);
            if (instr.Operand is IMethod opmeth && opmeth.IsMethod)
                b = comparer.Equals(opmeth, (IMethod)origInstr.Operand);
            else if (instr.Operand is IField opfld && opfld.IsField)
                b = comparer.Equals(opfld, (IField)origInstr.Operand);
            else if (instr.Operand is ITypeDefOrRef optyp)
                b = comparer.Equals(optyp, (ITypeDefOrRef)origInstr.Operand);
            else if (instr.OpCode.OperandType == OperandType.InlineVar || instr.OpCode.OperandType == OperandType.InlineBrTarget)
                b = true;
            else
                b = instr.Operand == null || instr.Operand.Equals(origInstr.Operand);
            if (!b)
            {
                Debug.Assert(instr.OpCode.Code == Code.Ldtoken);
                var optyp1 = instr.Operand as ITypeDefOrRef;
                var optyp2 = origInstr.Operand as TypeSpec;
                var optyp2instSig = optyp2.TypeSig as GenericInstSig;
                Debug.Assert(optyp1 != null && !optyp1.IsTypeSpec && optyp2 != null && optyp2instSig != null);
                var origTypeDef = optyp1.ResolveTypeDef();
                Debug.Assert(optyp2instSig.GenericArguments.Select(t => (t as GenericVar)?.Number).SequenceEqual(origTypeDef.GenericParameters.Select(t => (uint?)t.Number)));
            }
        }
        var exceptions = dmr.ExceptionHandlers;
        var origExceptions = md.Body.ExceptionHandlers;
        var locals = dmr.Locals;
        var origLocals = md.Body.Variables;
        for (int i = 0; i < exceptions.Count; i++)
        {
            var ex = exceptions[i];
            var origEx = origExceptions[i];
            bool b = comparer.Equals(ex.CatchType, origEx.CatchType);
            Debug.Assert(b);
        }
        for (int i = 0; i < locals.Count; i++)
        {
            var local = locals[i];
            var origLocal = origLocals[i];
            bool b = comparer.Equals(local.Type, origLocal.Type);
            Debug.Assert(b);
        }
        Console.WriteLine("OK");
        Console.Read();
    }
}

class My<T1, T2> : Exception where T1 : Exception where T2 : Exception
{
    public static T1 StaticField;
    public T1 InstanceField;

    public static void Test()
    {
        try
        {
            Console.WriteLine(typeof(T1));
            Console.WriteLine(typeof(My<,>));
            Console.WriteLine(typeof(My<T1, T2>));
            Console.WriteLine(typeof(My<T2, T1>));
            Console.WriteLine(StaticField);
            Console.WriteLine(My<Exception, Exception>.StaticField);
            Console.WriteLine(new My<Exception, Exception>().InstanceField);
            Console.WriteLine(new My<T1, T2>().InstanceField);
            Console.WriteLine(new My<T2, T1>().InstanceField);
            Activator.CreateInstance<T1>();
            var v1 = Activator.CreateInstance<My<T1, T2>>();
            var v2 = Activator.CreateInstance<My<T2, T1>>();
            Static();
            GenericStatic(StaticField);
            new My<Exception, T1>().Instance();
            new My<Exception, T2>().GenericInstance("");
            new My<T1, T2>().Instance();
            new My<T2, T1>().GenericInstance("");
            new List<T1>().Add(default);
            new List<int>().Add(0);
            new List<My<T1, T2>>().Add(default);
            new List<List<T1>>().Add(default);
        }
        catch (My<T1, T2> ex)
        {
        }
        catch (My<T2, T1> ex)
        {
        }
        catch (My<Exception, T2> ex)
        {
        }
        catch (T1 ex)
        {
        }
    }

    public static void Static() { }

    public static void GenericStatic<U>(U a) { }

    public void Instance() { }

    public void GenericInstance<U>(U a) { }
}
```

@ElektroKill @CreateAndInject 
