### PR TITLE
Add new `AllowByRefLike` generic parameter attribute

### DIFF
--- a/src/DotNet/GenericParam.cs
+++ b/src/DotNet/GenericParam.cs
@@ -260,6 +260,14 @@ namespace dnlib.DotNet {
 			set => ModifyAttributes(value, GenericParamAttributes.DefaultConstructorConstraint);
 		}
 
+		/// <summary>
+		/// Gets/sets the <see cref="GenericParamAttributes.AllowByRefLike"/> bit
+		/// </summary>
+		public bool AllowsByRefLike {
+			get => ((GenericParamAttributes)attributes & GenericParamAttributes.AllowByRefLike) != 0;
+			set => ModifyAttributes(value, GenericParamAttributes.AllowByRefLike);
+		}
+
 		/// <inheritdoc/>
 		void IListListener<GenericParamConstraint>.OnLazyAdd(int index, ref GenericParamConstraint value) => OnLazyAdd2(index, ref value);
 

--- a/src/DotNet/GenericParamAttributes.cs
+++ b/src/DotNet/GenericParamAttributes.cs
@@ -18,7 +18,7 @@ namespace dnlib.DotNet {
 		Contravariant			= 0x0002,
 
 		/// <summary/>
-		SpecialConstraintMask	= 0x001C,
+		SpecialConstraintMask	= 0x003C,
 		/// <summary/>
 		NoSpecialConstraint		= 0x0000,
 		/// <summary>type argument must be a reference type</summary>

--- a/src/DotNet/GenericParamAttributes.cs
+++ b/src/DotNet/GenericParamAttributes.cs
@@ -27,5 +27,7 @@ namespace dnlib.DotNet {
 		NotNullableValueTypeConstraint = 0x0008,
 		/// <summary>type argument must have a public default constructor</summary>
 		DefaultConstructorConstraint = 0x0010,
+		/// <summary>type argument can be ByRefLike</summary>
+		AllowByRefLike = 0x0020,
 	}
 }


### PR DESCRIPTION
See:
https://github.com/dotnet/runtime/blob/main/docs/design/features/byreflike-generics.md
https://github.com/dotnet/runtime/issues/102671
https://github.com/dotnet/runtime/blob/9daa4b41eb9f157e79eaf05e2f7451c9c8f6dbdc/src/coreclr/inc/corhdr.h#L847

The code responsible for this flag appears to be in the main branch of the runtime already.