### PR TITLE
Add MethodImplAttributes.Async flag

### DIFF
--- a/src/DotNet/MethodDef.cs
+++ b/src/DotNet/MethodDef.cs
@@ -856,6 +856,14 @@ namespace dnlib.DotNet {
 		}
 
 		/// <summary>
+		/// Gets/sets the <see cref="MethodImplAttributes.Async"/> bit
+		/// </summary>
+		public bool IsAsync {
+			get => ((MethodImplAttributes)implAttributes & MethodImplAttributes.Async) != 0;
+			set => ModifyImplAttributes(value, MethodImplAttributes.Async);
+		}
+
+		/// <summary>
 		/// Gets/sets the <see cref="MethodSemanticsAttributes.Setter"/> bit
 		/// </summary>
 		public bool IsSetter {

--- a/src/DotNet/MethodDef.cs
+++ b/src/DotNet/MethodDef.cs
@@ -498,6 +498,12 @@ namespace dnlib.DotNet {
 		/// <summary>
 		/// <c>true</c> if the method returns a value (i.e., return type is not <see cref="System.Void"/>)
 		/// </summary>
+		/// <remarks>
+		/// <see cref="MethodImplAttributes.Async"/> methods also do not have matching return type conventions as sync methods.
+		/// For sync methods, the stack should contain a value convertible to the stated return type before the <see cref="OpCodes.Ret"/> instruction.
+		/// For async methods, the stack should be empty in the case of <c>Task</c> or <c>ValueTask</c>, or the type argument in the case of <c>Task&lt;T&gt;</c> or <c>ValueTask&lt;T&gt;</c>.
+		/// <seealso href="https://github.com/dotnet/runtime/blob/main/docs/design/specs/runtime-async.md"/>
+		/// </remarks>
 		public bool HasReturnType => ReturnType.RemovePinnedAndModifiers().GetElementType() != ElementType.Void;
 
 		/// <summary>

--- a/src/DotNet/MethodImplAttributes.cs
+++ b/src/DotNet/MethodImplAttributes.cs
@@ -46,5 +46,7 @@ namespace dnlib.DotNet {
 		AggressiveOptimization	= 0x0200,
 		/// <summary>The JIT compiler should look for security mitigation attributes, such as the user-defined System.Runtime.CompilerServices.SecurityMitigationsAttribute. If found, the JIT compiler applies any related security mitigations. Available starting with .NET Framework 4.8.</summary>
 		SecurityMitigations		= 0x0400,
+		/// <summary>Method requires async state machine rewrite. Available starting with .NET 11.0.</summary>
+		Async					= 0x2000,
 	}
 }


### PR DESCRIPTION
Add the new Async flag for methods that was introduced for the new [Runtime-Async Feature](https://github.com/dotnet/runtime/issues/109632) in .NET 11.

See: 
<https://github.com/dotnet/runtime/blob/main/docs/design/specs/runtime-async.md>

<https://github.com/dotnet/runtime/blob/0c7ef81aa7d25dcac00eb81d156e03f4c0ca396b/src/coreclr/inc/corhdr.h#L650>

<https://github.com/dotnet/runtime/blob/0c7ef81aa7d25dcac00eb81d156e03f4c0ca396b/src/libraries/System.Private.CoreLib/src/System/Reflection/MethodImplAttributes.cs#L34>