### PR TITLE
Implement Improved MaxStackCalculator

### DIFF
--- a/src/DotNet/Writer/MaxStackCalculator.cs
+++ b/src/DotNet/Writer/MaxStackCalculator.cs
@@ -11,9 +11,9 @@ namespace dnlib.DotNet.Writer {
 	public struct MaxStackCalculator {
 		IList<Instruction> instructions;
 		IList<ExceptionHandler> exceptionHandlers;
-		readonly Dictionary<Instruction, int> stackHeights;
+		ushort?[] stackHeights;
+		uint maxStack;
 		bool hasError;
-		int currentMaxStack;
 
 		/// <summary>
 		/// Gets max stack value
@@ -36,142 +36,124 @@ namespace dnlib.DotNet.Writer {
 		public static bool GetMaxStack(IList<Instruction> instructions, IList<ExceptionHandler> exceptionHandlers, out uint maxStack) =>
 			new MaxStackCalculator(instructions, exceptionHandlers).Calculate(out maxStack);
 
-		internal static MaxStackCalculator Create() => new MaxStackCalculator(true);
-
-		MaxStackCalculator(bool dummy) {
-			instructions = null;
-			exceptionHandlers = null;
-			stackHeights = new Dictionary<Instruction, int>();
-			hasError = false;
-			currentMaxStack = 0;
+		/// <summary>
+		/// Gets the stack height for each instruction
+		/// </summary>
+		/// <param name="instructions">All instructions</param>
+		/// <param name="exceptionHandlers">All exception handlers</param>
+		/// <returns>The stack height for each instruction</returns>
+		public static ushort?[] GetStackHeights(IList<Instruction> instructions, IList<ExceptionHandler> exceptionHandlers) {
+			var helper = new MaxStackCalculator(instructions, exceptionHandlers);
+			helper.ExploreAll();
+			return helper.stackHeights;
 		}
 
-		MaxStackCalculator(IList<Instruction> instructions, IList<ExceptionHandler> exceptionHandlers) {
-			this.instructions = instructions;
-			this.exceptionHandlers = exceptionHandlers;
-			stackHeights = new Dictionary<Instruction, int>();
-			hasError = false;
-			currentMaxStack = 0;
-		}
+		internal static MaxStackCalculator Create() => new MaxStackCalculator();
+
+		MaxStackCalculator(IList<Instruction> instructions, IList<ExceptionHandler> exceptionHandlers) => Reset(instructions, exceptionHandlers);
 
 		internal void Reset(IList<Instruction> instructions, IList<ExceptionHandler> exceptionHandlers) {
 			this.instructions = instructions;
 			this.exceptionHandlers = exceptionHandlers;
-			stackHeights.Clear();
+			stackHeights = new ushort?[instructions.Count];
+			maxStack = 0;
 			hasError = false;
-			currentMaxStack = 0;
 		}
 
 		internal bool Calculate(out uint maxStack) {
-			var exceptionHandlers = this.exceptionHandlers;
-			var stackHeights = this.stackHeights;
-			for (int i = 0; i < exceptionHandlers.Count; i++) {
-				var eh = exceptionHandlers[i];
-				if (eh is null)
-					continue;
-				Instruction instr;
-				if ((instr = eh.TryStart) is not null)
-					stackHeights[instr] = 0;
-				if ((instr = eh.FilterStart) is not null) {
-					stackHeights[instr] = 1;
-					currentMaxStack = 1;
-				}
-				if ((instr = eh.HandlerStart) is not null) {
-					bool pushed = eh.IsCatch || eh.IsFilter;
-					if (pushed) {
-						stackHeights[instr] = 1;
-						currentMaxStack = 1;
-					}
-					else
-						stackHeights[instr] = 0;
-				}
-			}
-
-			int stack = 0;
-			bool resetStack = false;
-			var instructions = this.instructions;
-			for (int i = 0; i < instructions.Count; i++) {
-				var instr = instructions[i];
-				if (instr is null)
-					continue;
-
-				if (resetStack) {
-					stackHeights.TryGetValue(instr, out stack);
-					resetStack = false;
-				}
-				stack = WriteStack(instr, stack);
-				var opCode = instr.OpCode;
-				var code = opCode.Code;
-				if (code == Code.Jmp) {
-					if (stack != 0)
-						hasError = true;
-				}
-				else {
-					instr.CalculateStackUsage(out int pushes, out int pops);
-					if (pops == -1)
-						stack = 0;
-					else {
-						stack -= pops;
-						if (stack < 0) {
-							hasError = true;
-							stack = 0;
-						}
-						stack += pushes;
-					}
-				}
-				if (stack < 0) {
-					hasError = true;
-					stack = 0;
-				}
-
-				switch (opCode.FlowControl) {
-				case FlowControl.Branch:
-					WriteStack(instr.Operand as Instruction, stack);
-					resetStack = true;
-					break;
-
-				case FlowControl.Call:
-					if (code == Code.Jmp)
-						resetStack = true;
-					break;
-
-				case FlowControl.Cond_Branch:
-					if (code == Code.Switch) {
-						if (instr.Operand is IList<Instruction> targets) {
-							for (int j = 0; j < targets.Count; j++)
-								WriteStack(targets[j], stack);
-						}
-					}
-					else
-						WriteStack(instr.Operand as Instruction, stack);
-					break;
-
-				case FlowControl.Return:
-				case FlowControl.Throw:
-					resetStack = true;
-					break;
-				}
-			}
-
-			maxStack = (uint)currentMaxStack;
+			ExploreAll();
+			maxStack = this.maxStack;
 			return !hasError;
 		}
 
-		int WriteStack(Instruction instr, int stack) {
-			if (instr is null) {
-				hasError = true;
-				return stack;
+		void ExploreAll() {
+			Explore(0, 0);
+
+			foreach (var handler in exceptionHandlers) {
+				if (handler.FilterStart is not null) {
+					Explore(handler.FilterStart, 1);
+				}
+				if (handler.HandlerStart is not null) {
+					bool pushed = handler.IsCatch || handler.IsFilter;
+					Explore(handler.HandlerStart, (ushort)(pushed ? 1 : 0));
+				}
 			}
-			var stackHeights = this.stackHeights;
-			if (stackHeights.TryGetValue(instr, out int stack2)) {
-				if (stack != stack2)
+		}
+
+		void Explore(Instruction instr, ushort stackHeight) => Explore(instructions.IndexOf(instr), stackHeight);
+
+		void Explore(int index, ushort stackHeight) {
+start:
+			var previous = stackHeights[index];
+			if (previous is not null) {
+				if (previous != stackHeight) {
 					hasError = true;
-				return stack2;
+				}
+				return; // already visited this instruction
 			}
-			stackHeights[instr] = stack;
-			if (stack > currentMaxStack)
-				currentMaxStack = stack;
-			return stack;
+			stackHeights[index] = stackHeight;
+			if (stackHeight > maxStack)
+				maxStack = stackHeight;
+
+			var instr = instructions[index];
+			instr.CalculateStackUsage(out int pushes, out int pops);
+			if (pops == -1) {
+				stackHeight = 0;
+			}
+			else {
+				if (stackHeight < pops) {
+					hasError = true; // stack underflow
+					return;
+				}
+				stackHeight -= (ushort)pops;
+				stackHeight += (ushort)pushes;
+			}
+			switch (instr.OpCode.FlowControl) {
+			case FlowControl.Break:
+			case FlowControl.Call:
+			case FlowControl.Meta:
+			case FlowControl.Next: {
+				if (instr.OpCode.Code == Code.Jmp) {
+					return; // method terminates here
+				}
+				else {
+					index++;
+					goto start; // just continue to the next instruction
+				}
+			}
+			case FlowControl.Return: {
+				if (stackHeight > 1)
+					hasError = true;
+				return; // method terminates here
+			}
+			case FlowControl.Throw: {
+				return; // method terminates here
+			}
+			case FlowControl.Branch: // unconditional branch
+			{
+				var target = (Instruction)instr.Operand;
+				index = instructions.IndexOf(target);
+				goto start; // tail recursion
+			}
+			case FlowControl.Cond_Branch: {
+				if (instr.OpCode.Code == Code.Switch) {
+					foreach (var target in (IList<Instruction>)instr.Operand) {
+						Explore(target, stackHeight); // explore the branch target
+					}
+					index++;
+					goto start; // explore the next instruction
+				}
+				else {
+					var target = (Instruction)instr.Operand;
+					Explore(target, stackHeight); // explore the branch target
+					index++;
+					goto start; // explore the next instruction
+				}
+			}
+			default:
+				hasError = true;
+				return;
+			}
 		}
 	}
 }


### PR DESCRIPTION
I have refactored the `MaxStackCalculator` to be faster and not fail on obfuscated code.
The new implementation traverses the instructions the same way an IL interpreter would, using multiple recursion on branch instructions.
Here is the original: <https://github.com/PhilippNaused/Vilens/blob/main/src%2FVilens%2FHelpers%2FStackHelper.cs>

I tested this on multiple different libraries both before and after code obfuscation.
The old implementation would often fail on obfuscated code. This one doesn't.

The new version is also faster and uses less memory:

| Method | Mean     | Error     | StdDev    | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|------- |---------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
| old | 5.243 μs | 0.1259 μs | 0.1884 μs |  1.00 |    0.05 | 1.2894 | 0.0687 |  21.79 KB |        1.00 |
| new | 3.460 μs | 0.0594 μs | 0.0889 μs |  0.66 |    0.03 | 0.0725 |      - |   1.23 KB |        0.06 |
