### PR TITLE
Modernize examples

### DIFF
--- a/Examples/Example2.cs
+++ b/Examples/Example2.cs
@@ -56,7 +56,7 @@ namespace dnlib.Examples {
 			body.Instructions.Add(OpCodes.Ret.ToInstruction());
 
 			// Save the assembly to a file on disk
-			mod.Write(@"C:\saved-assembly.dll");
+			mod.Write(@"saved-assembly.dll");
 		}
 	}
 }

--- a/Examples/Example3.cs
+++ b/Examples/Example3.cs
@@ -28,7 +28,7 @@ namespace dnlib.Examples {
 			mod.Kind = ModuleKind.Console;
 
 			// Add the module to an assembly
-			var asm = new AssemblyDefUser("MyAssembly", new Version(1, 2, 3, 4), null, null);
+			var asm = new AssemblyDefUser("MyAssembly", new Version(1, 2, 3, 4), null, UTF8String.Empty);
 			asm.Modules.Add(mod);
 
 			// Add a .NET resource
@@ -72,7 +72,7 @@ namespace dnlib.Examples {
 			epBody.Instructions.Add(OpCodes.Ret.ToInstruction());
 
 			// Save the assembly to a file on disk
-			mod.Write(@"C:\saved-assembly.exe");
+			mod.Write(@"saved-assembly.exe");
 		}
 	}
 }

--- a/Examples/Example4.cs
+++ b/Examples/Example4.cs
@@ -63,7 +63,7 @@ namespace dnlib.Examples {
 	public class Example4 {
 		public static void Run() {
 			// This is the file that will be created
-			string newFileName = @"C:\ctor-test.exe";
+			string newFileName = @"ctor-test.exe";
 
 			// Create the module
 			var mod = new ModuleDefUser("ctor-test", Guid.NewGuid(),

--- a/Examples/Example5.cs
+++ b/Examples/Example5.cs
@@ -8,7 +8,7 @@ namespace dnlib.Examples {
 	/// </summary>
 	public class Example5 {
 		public static void Run() {
-			string sectionFileName = @"c:\section{0}.bin";
+			string sectionFileName = @"section{0}.bin";
 
 			// Open the current mscorlib
 			var mod = ModuleDefMD.Load(typeof(int).Module);

--- a/Examples/Example6.cs
+++ b/Examples/Example6.cs
@@ -16,7 +16,7 @@ namespace dnlib.Examples {
 		public static void Run() => new Example6().DoIt();
 
 		void DoIt() {
-			string destFileName = @"c:\output.dll";
+			string destFileName = @"output.dll";
 
 			// Open the current module
 			var mod = ModuleDefMD.Load(typeof(Example6).Module);

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net45</TargetFrameworks>
+    <TargetFrameworks>net10.0;net45</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
- Use .NET 10, since .NET 6 is not by default on new computer anymore and it's not supported
- You cannot save to drive C: in Windows 11 by default. Maybe just my computer, who knowns. Anyway, that make examples Windows only, which is unnecessary
- Example3 crashed, since invariant changed, and you should pass empty string as locale.