### PR TITLE
Preserve the type name string in `CustomMarshalType` if parsing it fails

### DIFF
--- a/src/DotNet/MarshalBlobReader.cs
+++ b/src/DotNet/MarshalBlobReader.cs
@@ -110,7 +110,7 @@ namespace dnlib.DotNet {
 					var custMarshalerName = ReadUTF8String();
 					var cmRef = custMarshalerName.DataLength == 0 ? null : TypeNameParser.ParseReflection(module, UTF8String.ToSystemStringOrEmpty(custMarshalerName), new CAAssemblyRefFinder(module), gpContext);
 					var cookie = ReadUTF8String();
-					returnValue = new CustomMarshalType(guid, nativeTypeName, cmRef, cookie);
+					returnValue = new CustomMarshalType(guid, nativeTypeName, custMarshalerName, cmRef, cookie);
 					break;
 
 				case NativeType.IUnknown:

--- a/src/DotNet/MarshalType.cs
+++ b/src/DotNet/MarshalType.cs
@@ -363,6 +363,7 @@ namespace dnlib.DotNet {
 	public sealed class CustomMarshalType : MarshalType {
 		UTF8String guid;
 		UTF8String nativeTypeName;
+		UTF8String custMarshalerTypeName;
 		ITypeDefOrRef custMarshaler;
 		UTF8String cookie;
 
@@ -383,7 +384,17 @@ namespace dnlib.DotNet {
 		}
 
 		/// <summary>
+		/// Gets/sets the custom marshaller type name string
+		/// <remarks>This property is used when writing only when <see cref="CustomMarshaler"/> is null.</remarks>
+		/// </summary>
+		public UTF8String CustomMarshalerTypeName {
+			get => custMarshalerTypeName;
+			set => custMarshalerTypeName = value;
+		}
+
+		/// <summary>
 		/// Gets/sets the custom marshaler
+		/// <remarks>This property takes priority over <see cref="CustomMarshalerTypeName"/> when writing.</remarks>
 		/// </summary>
 		public ITypeDefOrRef CustomMarshaler {
 			get => custMarshaler;
@@ -427,7 +438,7 @@ namespace dnlib.DotNet {
 		/// </summary>
 		/// <param name="guid">GUID string</param>
 		/// <param name="nativeTypeName">Native type name string</param>
-		/// <param name="custMarshaler">Custom marshaler name string</param>
+		/// <param name="custMarshaler">Custom marshaler type</param>
 		public CustomMarshalType(UTF8String guid, UTF8String nativeTypeName, ITypeDefOrRef custMarshaler)
 			: this(guid, nativeTypeName, custMarshaler, null) {
 		}
@@ -437,18 +448,35 @@ namespace dnlib.DotNet {
 		/// </summary>
 		/// <param name="guid">GUID string</param>
 		/// <param name="nativeTypeName">Native type name string</param>
-		/// <param name="custMarshaler">Custom marshaler name string</param>
+		/// <param name="custMarshaler">Custom marshaler type</param>
 		/// <param name="cookie">Cookie string</param>
 		public CustomMarshalType(UTF8String guid, UTF8String nativeTypeName, ITypeDefOrRef custMarshaler, UTF8String cookie)
+			: this(guid, nativeTypeName, null, custMarshaler, cookie) {
+		}
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="guid">GUID string</param>
+		/// <param name="nativeTypeName">Native type name string</param>
+		/// <param name="custMarshalerTypeName">Custom marshaler name string</param>
+		/// <param name="custMarshaler">Custom marshaler type</param>
+		/// <param name="cookie">Cookie string</param>
+		public CustomMarshalType(UTF8String guid, UTF8String nativeTypeName, UTF8String custMarshalerTypeName, ITypeDefOrRef custMarshaler, UTF8String cookie)
 			: base(NativeType.CustomMarshaler) {
 			this.guid = guid;
 			this.nativeTypeName = nativeTypeName;
+			this.custMarshalerTypeName = custMarshalerTypeName;
 			this.custMarshaler = custMarshaler;
 			this.cookie = cookie;
 		}
 
 		/// <inheritdoc/>
-		public override string ToString() => $"{nativeType} ({guid}, {nativeTypeName}, {custMarshaler}, {cookie})";
+		public override string ToString() {
+			if (custMarshaler is not null)
+				return $"{nativeType} ({guid}, {nativeTypeName}, {custMarshaler}, {cookie})";
+			return $"{nativeType} ({guid}, {nativeTypeName}, {custMarshalerTypeName}, {cookie})";
+		}
 	}
 
 	/// <summary>

--- a/src/DotNet/Writer/MarshalBlobWriter.cs
+++ b/src/DotNet/Writer/MarshalBlobWriter.cs
@@ -99,7 +99,7 @@ namespace dnlib.DotNet.Writer {
 				Write(custMarshaler.Guid);
 				Write(custMarshaler.NativeTypeName);
 				var cm = custMarshaler.CustomMarshaler;
-				var cmName = cm is null ? string.Empty : FullNameFactory.AssemblyQualifiedName(cm, this);
+				UTF8String cmName = cm is null ? custMarshaler.CustomMarshalerTypeName : FullNameFactory.AssemblyQualifiedName(cm, this);
 				Write(cmName);
 				Write(custMarshaler.Cookie);
 				break;


### PR DESCRIPTION
Currently, if the type name was not parsed, any empty string was written.

This has the side effect that code relying on `GetCustomAttribute<MarshalAsAttribute>()` will throw a different exception.

For example:
`System.ArgumentException: The name of the type is invalid. (Parameter 'typeName@0')`
vs.
`System.ArgumentException: The value cannot be an empty string. (Parameter 'typeName')`

This behavior could be used to detect rewriting with dnlib as a means of anti-tampering protection.