### PR TITLE
Dispose enumerators during type traversal

### DIFF
--- a/src/DotNet/AllTypesHelper.cs
+++ b/src/DotNet/AllTypesHelper.cs
@@ -14,21 +14,27 @@ namespace dnlib.DotNet {
 		public static IEnumerable<TypeDef> Types(IEnumerable<TypeDef> types) {
 			var visited = new Dictionary<TypeDef, bool>();
 			var stack = new Stack<IEnumerator<TypeDef>>();
-			if (types is not null)
-				stack.Push(types.GetEnumerator());
-			while (stack.Count > 0) {
-				var enumerator = stack.Pop();
-				while (enumerator.MoveNext()) {
+			try {
+				if (types is not null)
+					stack.Push(types.GetEnumerator());
+				while (stack.Count > 0) {
+					var enumerator = stack.Peek();
+					if (!enumerator.MoveNext()) {
+						stack.Pop().Dispose();
+						continue;
+					}
 					var type = enumerator.Current;
 					if (visited.ContainsKey(type))
 						continue;
 					visited[type] = true;
 					yield return type;
-					if (type.NestedTypes.Count > 0) {
-						stack.Push(enumerator);
-						enumerator = type.NestedTypes.GetEnumerator();
-					}
+					if (type.NestedTypes.Count > 0)
+						stack.Push(type.NestedTypes.GetEnumerator());
 				}
+			}
+			finally {
+				while (stack.Count > 0)
+					stack.Pop().Dispose();
 			}
 		}
 	}

--- a/src/DotNet/Writer/Metadata.cs
+++ b/src/DotNet/Writer/Metadata.cs
@@ -1825,20 +1825,26 @@ namespace dnlib.DotNet.Writer {
 			var sortedTypes = new List<ExportedType>(exportedTypes.Count);
 			var visited = new Dictionary<ExportedType, bool>();
 			var stack = new Stack<IEnumerator<ExportedType>>();
-			stack.Push(exportedTypes.GetEnumerator());
-			while (stack.Count > 0) {
-				var enumerator = stack.Pop();
-				while (enumerator.MoveNext()) {
+			try {
+				stack.Push(exportedTypes.GetEnumerator());
+				while (stack.Count > 0) {
+					var enumerator = stack.Peek();
+					if (!enumerator.MoveNext()) {
+						stack.Pop().Dispose();
+						continue;
+					}
 					var type = enumerator.Current;
 					if (visited.ContainsKey(type))
 						continue;
 					visited[type] = true;
 					sortedTypes.Add(type);
-					if (nestedTypeDict.TryGetValue(type, out var nested) && nested.Count > 0) {
-						stack.Push(enumerator);
-						enumerator = nested.GetEnumerator();
-					}
+					if (nestedTypeDict.TryGetValue(type, out var nested) && nested.Count > 0)
+						stack.Push(nested.GetEnumerator());
 				}
+			}
+			finally {
+				while (stack.Count > 0)
+					stack.Pop().Dispose();
 			}
 
 			int count = sortedTypes.Count;


### PR DESCRIPTION
This change addresses #560 by ensuring that enumerators created by `AllTypesHelper.Types()` and `Metadata.AddExportedTypes()` are properly disposed.

Enumerators are disposed as soon as they are exhausted, while a `finally` block disposes any that remain active if traversal ends early or due to an exception.

This is especially important for `AllTypesHelper.Types()`, where callers may stop enumeration before the full type hierarchy has been traversed.

Fixes #560